### PR TITLE
Add basic Pokémon analysis library and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Pokémon Analyzer
+
+Simple library and CLI for Pokémon GO stat analysis.
+
+## Usage
+```bash
+python -m pogo_analyzer.cli --species Bulbasaur --iv 0 15 15 --level 20
+```
+This prints PvE breakpoints and PvP league recommendations.

--- a/src/pogo_analyzer/__init__.py
+++ b/src/pogo_analyzer/__init__.py
@@ -1,0 +1,5 @@
+"""Pokémon GO analysis library."""
+
+from . import data_loader, calculations, analysis
+
+__all__ = ["data_loader", "calculations", "analysis"]

--- a/src/pogo_analyzer/analysis.py
+++ b/src/pogo_analyzer/analysis.py
@@ -1,0 +1,43 @@
+"""High level Pokémon analysis functions."""
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+from . import data_loader, calculations
+from .models import PokemonSpecies, Move
+
+
+def analyze_pokemon(
+    name: str,
+    form: str,
+    ivs: Tuple[int, int, int],
+    level: float,
+    *,
+    shadow: bool = False,
+    purified: bool = False,
+    best_buddy: bool = False,
+) -> Dict:
+    stats_map = data_loader.load_pokemon_stats()
+    moves_map = data_loader.load_pokemon_moves()
+    move_data = data_loader.load_moves()
+
+    species: PokemonSpecies = stats_map[name][form]
+    stats = calculations.compute_stats(
+        species, ivs, level, shadow=shadow, purified=purified, buddy=best_buddy
+    )
+    cp = calculations.calc_cp(stats, stats["level"])
+
+    moves = moves_map[name][form]
+    fast_move: Move = move_data[moves["fast"][0]]
+    charged_move: Move = move_data[moves["charged"][0]]
+    pve_bp = calculations.pve_breakpoints(stats, fast_move, boss_def=200)
+    pve_sc = calculations.pve_score(stats, {"fast": fast_move, "charged": charged_move})
+    pvp_rec = calculations.pvp_recommendation(species, ivs)
+    return {
+        "name": name,
+        "form": form,
+        "level": stats["level"],
+        "cp": cp,
+        "pve": {"breakpoints": pve_bp, "score": pve_sc},
+        "pvp": pvp_rec,
+    }

--- a/src/pogo_analyzer/calculations.py
+++ b/src/pogo_analyzer/calculations.py
@@ -1,0 +1,103 @@
+"""Core stat and CP calculations."""
+from __future__ import annotations
+
+from math import floor, sqrt
+from typing import Dict, Tuple
+
+from .models import PokemonSpecies, Move
+from . import data_loader
+
+
+def compute_stats(
+    species: PokemonSpecies,
+    ivs: Tuple[int, int, int],
+    level: float,
+    shadow: bool = False,
+    purified: bool = False,
+    buddy: bool = False,
+) -> Dict[str, float]:
+    """Return effective attack, defense, stamina, and level."""
+    atk = species.base_attack + ivs[0]
+    defense = species.base_defense + ivs[1]
+    stamina = species.base_stamina + ivs[2]
+    if shadow:
+        atk *= data_loader.SHADOW_ATTACK_MULT
+        defense *= data_loader.SHADOW_DEFENSE_MULT
+    if purified:
+        atk += data_loader.PURIFIED_ATTACK_BONUS
+        defense *= data_loader.PURIFIED_DEFENSE_MULT
+    eff_level = level + (data_loader.BEST_BUDDY_LEVEL_BONUS if buddy else 0)
+    return {"attack": atk, "defense": defense, "stamina": stamina, "level": eff_level}
+
+
+def calc_cp(stats: Dict[str, float], level: float) -> int:
+    multipliers = data_loader.load_cp_multipliers()
+    m = multipliers.get(level)
+    if m is None:
+        raise ValueError(f"Unknown CP multiplier for level {level}")
+    cp = floor(
+        (stats["attack"] * sqrt(stats["defense"]) * sqrt(stats["stamina"]) * m * m)
+        / 10
+    )
+    return max(10, int(cp))
+
+
+def pve_breakpoints(stats: Dict[str, float], move: Move, boss_def: float) -> Tuple[Tuple[float, int], ...]:
+    """Return levels where fast move damage increases against a boss."""
+    mults = data_loader.load_cp_multipliers()
+    out = []
+    prev = None
+    for level in sorted(mults):
+        if level < 1 or level > 50:
+            continue
+        atk = stats["attack"] * mults[level]
+        dmg = floor(0.5 * move.power * atk / boss_def) + 1
+        if prev is None or dmg > prev:
+            out.append((level, dmg))
+            prev = dmg
+    return tuple(out)
+
+
+def pve_score(stats: Dict[str, float], moveset: Dict[str, Move]) -> float:
+    fast = moveset["fast"]
+    charged = moveset["charged"]
+    dps = fast.power / max(fast.duration, 1) + charged.power / max(charged.duration, 1)
+    return stats["attack"] * dps
+
+
+def maximize_stat_product(
+    species: PokemonSpecies, ivs: Tuple[int, int, int], league_cap: int
+) -> Dict[str, float]:
+    mults = data_loader.load_cp_multipliers()
+    best = {
+        "level": 1.0,
+        "cp": 10,
+        "stat_product": 0.0,
+        "requires_xl": False,
+    }
+    for level in sorted(mults):
+        if level > 55:
+            continue
+        stats = compute_stats(species, ivs, level)
+        cp = calc_cp(stats, level)
+        if cp > league_cap:
+            break
+        product = stats["attack"] * stats["defense"] * stats["stamina"]
+        if product > best["stat_product"]:
+            best = {
+                "level": level,
+                "cp": cp,
+                "stat_product": product,
+                "requires_xl": level > 40,
+            }
+    best["second_move_cost"] = {"stardust": 50000, "candy": 50}
+    return best
+
+
+def pvp_recommendation(
+    species: PokemonSpecies, ivs: Tuple[int, int, int]
+) -> Dict[str, Dict[str, float]]:
+    rec = {}
+    for league, cap in data_loader.LEAGUE_CP_CAPS.items():
+        rec[league] = maximize_stat_product(species, ivs, cap)
+    return rec

--- a/src/pogo_analyzer/cli.py
+++ b/src/pogo_analyzer/cli.py
@@ -1,0 +1,52 @@
+"""Command line interface for Pokémon analysis."""
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Tuple
+
+from .analysis import analyze_pokemon
+
+
+def parse_iv(string_list) -> Tuple[int, int, int]:
+    if len(string_list) != 3:
+        raise argparse.ArgumentTypeError("IV requires three integers")
+    return tuple(int(x) for x in string_list)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Analyze a single Pokémon")
+    parser.add_argument("--species", required=True)
+    parser.add_argument("--form", default="Normal")
+    parser.add_argument("--iv", nargs=3, metavar=("ATK", "DEF", "STA"), required=True)
+    parser.add_argument("--level", type=float, default=1.0)
+    parser.add_argument("--shadow", action="store_true")
+    parser.add_argument("--purified", action="store_true")
+    parser.add_argument("--best-buddy", action="store_true", dest="best_buddy")
+    parser.add_argument("--output", choices=["text", "json"], default="text")
+    args = parser.parse_args()
+
+    ivs = parse_iv(args.iv)
+    result = analyze_pokemon(
+        args.species,
+        args.form,
+        ivs,
+        args.level,
+        shadow=args.shadow,
+        purified=args.purified,
+        best_buddy=args.best_buddy,
+    )
+
+    if args.output == "json":
+        print(json.dumps(result, indent=2))
+    else:
+        print(f"{result['name']} ({result['form']}) - CP {result['cp']}")
+        for league, data in result["pvp"].items():
+            print(
+                f"{league.title()} League: level {data['level']}, CP {data['cp']}, "
+                f"XL required: {data['requires_xl']}"
+            )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/pogo_analyzer/data_loader.py
+++ b/src/pogo_analyzer/data_loader.py
@@ -1,0 +1,88 @@
+"""Load static Pokémon GO reference data."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List
+
+from .models import PokemonSpecies, Move, CPMultiplier
+
+# Directory containing JSON data files
+DATA_DIR = Path(__file__).resolve().parents[2] / "data"
+
+# Constants
+SHADOW_ATTACK_MULT = 1.2
+SHADOW_DEFENSE_MULT = 0.833
+PURIFIED_ATTACK_BONUS = 0
+PURIFIED_DEFENSE_MULT = 1.0
+BEST_BUDDY_LEVEL_BONUS = 1.0
+LEAGUE_CP_CAPS = {"great": 1500, "ultra": 2500, "master": 10000}
+
+
+def _load_json(name: str) -> List[Dict]:
+    return json.loads((DATA_DIR / name).read_text())
+
+
+def load_pokemon_stats() -> Dict[str, Dict[str, PokemonSpecies]]:
+    raw = _load_json("pokemon_stats.json")
+    out: Dict[str, Dict[str, PokemonSpecies]] = {}
+    for entry in raw:
+        species = PokemonSpecies(
+            pokemon_id=entry["pokemon_id"],
+            name=entry["pokemon_name"],
+            form=entry.get("form", "Normal"),
+            base_attack=entry["base_attack"],
+            base_defense=entry["base_defense"],
+            base_stamina=entry["base_stamina"],
+        )
+        out.setdefault(species.name, {})[species.form] = species
+    return out
+
+
+def load_moves() -> Dict[str, Move]:
+    fast = _load_json("fast_moves.json")
+    charged = _load_json("charged_moves.json")
+    moves: Dict[str, Move] = {}
+    for entry in fast:
+        moves[entry["name"]] = Move(
+            move_id=entry["move_id"],
+            name=entry["name"],
+            type=entry["type"],
+            power=entry.get("power", 0),
+            energy_delta=entry.get("energy_delta", 0),
+            duration=entry.get("duration", 0),
+            is_fast=True,
+        )
+    for entry in charged:
+        moves[entry["name"]] = Move(
+            move_id=entry["move_id"],
+            name=entry["name"],
+            type=entry["type"],
+            power=entry.get("power", 0),
+            energy_delta=entry.get("energy_delta", 0),
+            duration=entry.get("duration", 0),
+            is_fast=False,
+        )
+    return moves
+
+
+def load_pokemon_moves() -> Dict[str, Dict[str, Dict[str, List[str]]]]:
+    raw = _load_json("pokemon_moves.json")
+    out: Dict[str, Dict[str, Dict[str, List[str]]]] = {}
+    for entry in raw:
+        name = entry["pokemon_name"]
+        form = entry.get("form", "Normal")
+        out.setdefault(name, {})[form] = {
+            "fast": entry["fast_moves"],
+            "charged": entry["charged_moves"],
+        }
+    return out
+
+
+def load_cp_multipliers() -> Dict[float, float]:
+    raw = _load_json("cp_multipliers.json")
+    return {entry["level"]: entry["multiplier"] for entry in raw}
+
+
+def load_type_effectiveness() -> Dict[str, Dict[str, float]]:
+    return {k: v for k, v in _load_json("type_effectiveness.json").items()}

--- a/src/pogo_analyzer/models.py
+++ b/src/pogo_analyzer/models.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class PokemonSpecies:
+    """Species stats and identifiers."""
+    pokemon_id: int
+    name: str
+    form: str
+    base_attack: int
+    base_defense: int
+    base_stamina: int
+
+
+@dataclass
+class Move:
+    """Move data."""
+    move_id: int
+    name: str
+    type: str
+    power: int
+    energy_delta: int
+    duration: int
+    is_fast: bool
+
+
+@dataclass
+class CPMultiplier:
+    """CP multiplier for a level."""
+    level: float
+    multiplier: float

--- a/tests/test_calculations.py
+++ b/tests/test_calculations.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from pogo_analyzer.data_loader import load_pokemon_stats
+from pogo_analyzer.calculations import compute_stats, calc_cp, pvp_recommendation
+
+
+def test_cp_dragonite_level40():
+    stats_map = load_pokemon_stats()
+    dragonite = stats_map['Dragonite']['Normal']
+    eff = compute_stats(dragonite, (15, 15, 15), 40.0)
+    cp = calc_cp(eff, eff['level'])
+    assert cp == 3792
+
+
+def test_pvp_recommendation_great_league():
+    stats_map = load_pokemon_stats()
+    bulba = stats_map['Bulbasaur']['Normal']
+    rec = pvp_recommendation(bulba, (0, 15, 15))
+    assert 'great' in rec
+    assert rec['great']['cp'] <= 1500
+    assert rec['great']['level'] <= 50

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from pathlib import Path
+import subprocess
+
+ROOT = Path(__file__).resolve().parents[1]
+PYTHONPATH = str(ROOT / 'src')
+
+
+def test_cli_runs():
+    env = os.environ.copy()
+    env['PYTHONPATH'] = PYTHONPATH
+    result = subprocess.run(
+        [sys.executable, '-m', 'pogo_analyzer.cli', '--species', 'Bulbasaur', '--iv', '0', '0', '0', '--level', '1'],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0
+    assert 'Bulbasaur' in result.stdout
+    assert 'Great League' in result.stdout

--- a/tests/test_data_loader.py
+++ b/tests/test_data_loader.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from pogo_analyzer.data_loader import (
+    load_pokemon_stats,
+    load_moves,
+    load_pokemon_moves,
+    load_cp_multipliers,
+    load_type_effectiveness,
+    SHADOW_ATTACK_MULT,
+    LEAGUE_CP_CAPS,
+)
+from pogo_analyzer.models import PokemonSpecies, Move
+
+
+def test_load_pokemon_stats():
+    stats = load_pokemon_stats()
+    bulba = stats['Bulbasaur']['Normal']
+    assert isinstance(bulba, PokemonSpecies)
+    assert bulba.base_attack == 118
+
+
+def test_load_moves():
+    moves = load_moves()
+    vine = moves['Vine Whip']
+    assert isinstance(vine, Move)
+    assert vine.power == 6
+    assert vine.is_fast
+
+
+def test_constants_and_multipliers():
+    mult = load_cp_multipliers()
+    assert 1.0 in mult
+    assert SHADOW_ATTACK_MULT > 1
+    assert LEAGUE_CP_CAPS['great'] == 1500
+
+
+def test_type_effectiveness():
+    eff = load_type_effectiveness()
+    assert eff['Grass']['Water'] > 1


### PR DESCRIPTION
## Summary
- add data models and loaders for Pokémon stats, moves, multipliers
- implement stat, CP, PvE and PvP calculations
- provide analysis entrypoint, command-line interface and documentation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c883d28fc48328b6b0359d1e917894