### PR TITLE
Add event feed parsing and surface active modifiers

### DIFF
--- a/src/pogo_analyzer/__init__.py
+++ b/src/pogo_analyzer/__init__.py
@@ -1,5 +1,5 @@
 """Pokémon GO analysis library."""
 
-from . import data_loader, calculations, analysis, team_builder
+from . import data_loader, calculations, analysis, team_builder, events
 
-__all__ = ["data_loader", "calculations", "analysis", "team_builder"]
+__all__ = ["data_loader", "calculations", "analysis", "team_builder", "events"]

--- a/src/pogo_analyzer/analysis.py
+++ b/src/pogo_analyzer/analysis.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, Tuple
 
-from . import data_loader, calculations
+from . import data_loader, calculations, events
 from .models import PokemonSpecies, Move
 
 
@@ -20,6 +20,7 @@ def analyze_pokemon(
     stats_map = data_loader.load_pokemon_stats()
     moves_map = data_loader.load_pokemon_moves()
     move_data = data_loader.load_moves()
+    event_modifiers = events.get_active_modifiers()
 
     species: PokemonSpecies = stats_map[name][form]
     stats = calculations.compute_stats(
@@ -28,16 +29,79 @@ def analyze_pokemon(
     cp = calculations.calc_cp(stats, stats["level"])
 
     moves = moves_map[name][form]
-    fast_move: Move = move_data[moves["fast"][0]]
-    charged_move: Move = move_data[moves["charged"][0]]
+    selected_moves = {
+        "fast": list(moves["fast"]),
+        "charged": list(moves["charged"]),
+    }
+
+    event_move_override = (
+        event_modifiers.get("moves", {})
+        .get(name, {})
+        .get(form)
+    )
+    if event_move_override:
+        if event_move_override.get("fast"):
+            selected_moves["fast"] = event_move_override["fast"]
+        if event_move_override.get("charged"):
+            selected_moves["charged"] = event_move_override["charged"]
+
+    def resolve_move(candidates, fallback):
+        for move_name in candidates:
+            move = move_data.get(move_name)
+            if move is not None:
+                return move
+        for move_name in fallback:
+            move = move_data.get(move_name)
+            if move is not None:
+                return move
+        raise KeyError(f"No known moves available for {name} ({form})")
+
+    fast_move: Move = resolve_move(selected_moves["fast"], moves["fast"])
+    charged_move: Move = resolve_move(selected_moves["charged"], moves["charged"])
     pve_bp = calculations.pve_breakpoints(stats, fast_move, boss_def=200)
     pve_sc = calculations.pve_score(stats, {"fast": fast_move, "charged": charged_move})
-    pvp_rec = calculations.pvp_recommendation(species, ivs)
+    league_caps = dict(data_loader.LEAGUE_CP_CAPS)
+    applied_cp_caps = {}
+    for league, override in event_modifiers.get("cp_caps", {}).items():
+        value = override.get("value") if isinstance(override, dict) else override
+        if value is None:
+            continue
+        league_caps[league] = int(value)
+        applied_cp_caps[league] = {
+            "value": int(value),
+            "event": override.get("event") if isinstance(override, dict) else None,
+        }
+
+    pvp_rec = calculations.pvp_recommendation(species, ivs, league_caps=league_caps)
+    for league, modifier in applied_cp_caps.items():
+        if league in pvp_rec:
+            pvp_rec[league]["event_modifier"] = modifier
+
+    event_summary = {
+        "active_events": list(event_modifiers.get("active_events", [])),
+        "moves": {},
+        "cp_caps": applied_cp_caps,
+    }
+    if event_move_override:
+        event_summary["moves"] = {
+            name: {
+                form: {
+                    "fast": list(event_move_override.get("fast", [])),
+                    "charged": list(event_move_override.get("charged", [])),
+                    "event": event_move_override.get("event"),
+                }
+            }
+        }
     return {
         "name": name,
         "form": form,
         "level": stats["level"],
         "cp": cp,
-        "pve": {"breakpoints": pve_bp, "score": pve_sc},
+        "pve": {
+            "breakpoints": pve_bp,
+            "score": pve_sc,
+            "moveset": {"fast": fast_move.name, "charged": charged_move.name},
+        },
         "pvp": pvp_rec,
+        "event_modifiers": event_summary,
     }

--- a/src/pogo_analyzer/calculations.py
+++ b/src/pogo_analyzer/calculations.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from math import floor, sqrt
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 from .models import PokemonSpecies, Move
 from . import data_loader
@@ -95,9 +95,15 @@ def maximize_stat_product(
 
 
 def pvp_recommendation(
-    species: PokemonSpecies, ivs: Tuple[int, int, int]
+    species: PokemonSpecies,
+    ivs: Tuple[int, int, int],
+    *,
+    league_caps: Optional[Dict[str, int]] = None,
 ) -> Dict[str, Dict[str, float]]:
-    rec = {}
-    for league, cap in data_loader.LEAGUE_CP_CAPS.items():
-        rec[league] = maximize_stat_product(species, ivs, cap)
+    caps = league_caps or data_loader.LEAGUE_CP_CAPS
+    rec: Dict[str, Dict[str, float]] = {}
+    for league, cap in caps.items():
+        league_rec = maximize_stat_product(species, ivs, cap)
+        league_rec["cap"] = cap
+        rec[league] = league_rec
     return rec

--- a/src/pogo_analyzer/cli.py
+++ b/src/pogo_analyzer/cli.py
@@ -149,11 +149,46 @@ def main() -> None:
         print(json.dumps(result, indent=2))
     else:
         print(f"{result['name']} ({result['form']}) - CP {result['cp']}")
+        event_modifiers = result.get("event_modifiers", {})
+        active_events = event_modifiers.get("active_events", [])
+        if active_events:
+            print("Active modifiers: " + ", ".join(active_events))
+
+        move_override = (
+            event_modifiers.get("moves", {})
+            .get(result["name"], {})
+            .get(result["form"])
+        )
+        if move_override:
+            fast_moves = ", ".join(move_override.get("fast", [])) or "—"
+            charged_moves = ", ".join(move_override.get("charged", [])) or "—"
+            event_name = move_override.get("event")
+            if event_name:
+                print(
+                    f"Moves adjusted by {event_name}: fast {fast_moves}; "
+                    f"charged {charged_moves}"
+                )
+            else:
+                print(
+                    f"Moves adjusted for event: fast {fast_moves}; "
+                    f"charged {charged_moves}"
+                )
+
+        cp_overrides = event_modifiers.get("cp_caps", {})
         for league, data in result["pvp"].items():
-            print(
+            line = (
                 f"{league.title()} League: level {data['level']}, CP {data['cp']}, "
                 f"XL required: {data['requires_xl']}"
             )
+            override = cp_overrides.get(league)
+            if isinstance(override, dict) and override.get("value") is not None:
+                line += f" [Event cap {override['value']}"
+                if override.get("event"):
+                    line += f" ({override['event']})"
+                line += "]"
+            elif override:
+                line += f" [Event cap {override}]"
+            print(line)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/pogo_analyzer/events.py
+++ b/src/pogo_analyzer/events.py
@@ -1,0 +1,151 @@
+"""Utilities for fetching and parsing temporary game events."""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+from urllib.error import URLError
+from urllib.request import urlopen
+
+DEFAULT_EVENT_FEED = os.environ.get("POGO_ANALYZER_EVENT_FEED", "")
+
+
+def _parse_timestamp(value: str) -> datetime:
+    """Parse an ISO-8601 timestamp into a timezone-aware datetime."""
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def fetch_event_data(source: Optional[str] = None) -> Dict[str, Any]:
+    """Return the raw JSON payload for the configured event feed.
+
+    The feed can be provided via an explicit ``source`` argument, an environment
+    variable (``POGO_ANALYZER_EVENT_FEED``), or will default to an empty
+    collection when no feed is configured. ``source`` may point to a HTTP(S)
+    endpoint or a local JSON file.
+    """
+
+    src = source or DEFAULT_EVENT_FEED
+    if not src:
+        return {"events": []}
+
+    try:
+        if src.startswith(("http://", "https://")):
+            with urlopen(src, timeout=5) as response:  # nosec - controlled input
+                payload = response.read().decode("utf-8")
+            data = json.loads(payload)
+        else:
+            data = json.loads(Path(src).read_text())
+    except FileNotFoundError:
+        return {"events": []}
+    except URLError:
+        return {"events": []}
+
+    if isinstance(data, list):
+        return {"events": data}
+    if isinstance(data, dict):
+        events = data.get("events")
+        if events is None:
+            raise ValueError("Event feed is missing an 'events' key")
+        if not isinstance(events, list):
+            raise ValueError("The 'events' entry must be a list")
+        return {"events": events}
+    raise ValueError("Unsupported event feed structure")
+
+
+def _normalize_moves(raw_moves: Dict[str, Any]) -> Dict[str, Dict[str, Dict[str, List[str]]]]:
+    """Normalize move modifiers into a species/form keyed mapping."""
+
+    normalized: Dict[str, Dict[str, Dict[str, List[str]]]] = {}
+    for species, forms in raw_moves.items():
+        if not isinstance(forms, dict):
+            continue
+        species_entry: Dict[str, Dict[str, List[str]]] = {}
+        for form, move_data in forms.items():
+            if not isinstance(move_data, dict):
+                continue
+            fast = move_data.get("fast", [])
+            charged = move_data.get("charged", [])
+            species_entry[form] = {
+                "fast": list(fast),
+                "charged": list(charged),
+            }
+        if species_entry:
+            normalized[species] = species_entry
+    return normalized
+
+
+def _normalize_cp_caps(raw_caps: Dict[str, Any]) -> Dict[str, int]:
+    """Normalize CP cap overrides into integer values."""
+
+    caps: Dict[str, int] = {}
+    for league, value in raw_caps.items():
+        try:
+            caps[league] = int(value)
+        except (TypeError, ValueError):
+            continue
+    return caps
+
+
+def parse_events(raw_events: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Convert raw event dictionaries into a normalized structure."""
+
+    events: List[Dict[str, Any]] = []
+    for entry in raw_events:
+        try:
+            start = _parse_timestamp(entry["start"])
+            end = _parse_timestamp(entry["end"])
+        except (KeyError, ValueError):
+            continue
+        modifiers = entry.get("modifiers", {})
+        moves = _normalize_moves(modifiers.get("moves", {}))
+        cp_caps = _normalize_cp_caps(modifiers.get("cp_caps", {}))
+        events.append(
+            {
+                "name": entry.get("name", "Unnamed Event"),
+                "start": start,
+                "end": end,
+                "modifiers": {
+                    "moves": moves,
+                    "cp_caps": cp_caps,
+                },
+            }
+        )
+    return events
+
+
+def get_active_modifiers(
+    *, reference: Optional[datetime] = None, source: Optional[str] = None
+) -> Dict[str, Any]:
+    """Return combined modifiers for events active at ``reference`` time."""
+
+    payload = fetch_event_data(source)
+    events = parse_events(payload.get("events", []))
+
+    if reference is None:
+        now = datetime.now(timezone.utc)
+    else:
+        now = reference if reference.tzinfo else reference.replace(tzinfo=timezone.utc)
+        now = now.astimezone(timezone.utc)
+
+    summary: Dict[str, Any] = {"active_events": [], "moves": {}, "cp_caps": {}}
+
+    for event in events:
+        if event["start"] <= now <= event["end"]:
+            summary["active_events"].append(event["name"])
+            for league, cap in event["modifiers"]["cp_caps"].items():
+                summary["cp_caps"][league] = {"value": cap, "event": event["name"]}
+            for species, forms in event["modifiers"]["moves"].items():
+                species_entry = summary["moves"].setdefault(species, {})
+                for form, move_data in forms.items():
+                    species_entry[form] = {
+                        "fast": list(move_data.get("fast", [])),
+                        "charged": list(move_data.get("charged", [])),
+                        "event": event["name"],
+                    }
+
+    return summary

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,58 @@
+import json
+from datetime import datetime, timezone
+
+from pogo_analyzer import events
+
+
+def _write_event_feed(tmp_path):
+    payload = {
+        "events": [
+            {
+                "name": "Great League Remix",
+                "start": "2023-01-01T00:00:00Z",
+                "end": "2023-01-07T23:59:59Z",
+                "modifiers": {
+                    "moves": {
+                        "Bulbasaur": {
+                            "Normal": {
+                                "fast": ["Vine Whip"],
+                                "charged": ["Seed Bomb"],
+                            }
+                        }
+                    },
+                    "cp_caps": {"great": 1400},
+                },
+            }
+        ]
+    }
+    path = tmp_path / "events.json"
+    path.write_text(json.dumps(payload))
+    return path, payload
+
+
+def test_fetch_event_data_from_file(tmp_path):
+    path, payload = _write_event_feed(tmp_path)
+    loaded = events.fetch_event_data(str(path))
+    assert loaded == payload
+
+
+def test_get_active_modifiers(tmp_path):
+    path, _ = _write_event_feed(tmp_path)
+    reference = datetime(2023, 1, 5, tzinfo=timezone.utc)
+    modifiers = events.get_active_modifiers(reference=reference, source=str(path))
+
+    assert modifiers["active_events"] == ["Great League Remix"]
+    cp_caps = modifiers["cp_caps"]
+    assert cp_caps["great"]["value"] == 1400
+    assert cp_caps["great"]["event"] == "Great League Remix"
+
+    moves = modifiers["moves"]["Bulbasaur"]["Normal"]
+    assert moves["fast"] == ["Vine Whip"]
+    assert moves["charged"] == ["Seed Bomb"]
+    assert moves["event"] == "Great League Remix"
+
+    inactive = events.get_active_modifiers(
+        reference=datetime(2023, 2, 1, tzinfo=timezone.utc),
+        source=str(path),
+    )
+    assert inactive == {"active_events": [], "moves": {}, "cp_caps": {}}


### PR DESCRIPTION
## Summary
- add an events helper module to fetch a JSON feed and determine active move/CP modifiers
- integrate active modifiers into Pokémon analysis and highlight them in the CLI output
- cover the new behaviour with targeted unit tests and allow PvP calculations to accept custom league caps

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c88d7e911c8328b72f4a7cd883ff66