### PR TITLE
Add scan REST API and mobile capture screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,31 @@ Simple library and CLI for Pokémon GO stat analysis.
 python -m pogo_analyzer.cli --species Bulbasaur --iv 0 15 15 --level 20
 ```
 This prints PvE breakpoints and PvP league recommendations.
+
+## REST API
+
+The project ships with an optional FastAPI application that exposes the
+`scan_screenshot` helper over HTTP.
+
+```bash
+uvicorn pogo_analyzer.api:app --reload
+```
+
+Send a `multipart/form-data` request containing an image file to analyse it:
+
+```bash
+curl -F "file=@/path/to/screenshot.png" http://localhost:8000/scan
+```
+
+If FastAPI is not installed, install it first:
+
+```bash
+pip install fastapi uvicorn
+```
+
+## Mobile capture screen
+
+A React Native capture and review screen lives in `mobile/src/screens/CaptureScreen.tsx`.
+It lets you capture or pick screenshots, sends them to the REST API, and caches the most
+recent analyses (via AsyncStorage) for offline review. See `mobile/README.md` for setup
+instructions.

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,0 +1,44 @@
+# Mobile Capture App
+
+This directory contains a lightweight React Native screen for capturing Pokémon GO
+screenshots, sending them to the Pokémon Analyzer REST API, and caching the results for
+offline review.
+
+## Prerequisites
+
+- [Expo CLI](https://docs.expo.dev/get-started/installation/) or a React Native project
+  configured with `expo-image-picker` and `@react-native-async-storage/async-storage`.
+- A running instance of the Pokémon Analyzer API (see project README) reachable from your
+  device or emulator.
+
+Install the dependencies inside your mobile project:
+
+```bash
+expo install expo-image-picker @react-native-async-storage/async-storage
+```
+
+If you are using bare React Native, follow the installation instructions provided by each
+package.
+
+## Usage
+
+1. Copy `src/screens/CaptureScreen.tsx` into your application and register it with your
+   navigator (e.g. React Navigation).
+2. Provide the API base URL via the `EXPO_PUBLIC_API_BASE_URL` or `API_BASE_URL`
+   environment variable. For Expo, create an `app.config.js` entry or use `app.json`.
+3. Launch the screen on a device/emulator, capture or select a screenshot, then tap
+   **Analyze** to send it to the backend.
+4. Successful scans are cached locally (AsyncStorage) so that the "Recent scans" carousel
+   remains available when offline.
+
+## Environment variables
+
+- `EXPO_PUBLIC_API_BASE_URL` (preferred) – API URL exposed to the app at build time.
+- `API_BASE_URL` – fallback used if the Expo public variable is not set.
+
+## Offline cache
+
+Scan results are persisted in `AsyncStorage` under the key
+`@pogo_analyzer_recent_scans`. Up to 12 entries are retained, keeping the newest results
+first. The history list on the screen lets players revisit past analyses without an
+active network connection.

--- a/mobile/src/screens/CaptureScreen.tsx
+++ b/mobile/src/screens/CaptureScreen.tsx
@@ -1,0 +1,387 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  Image,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import * as ImagePicker from "expo-image-picker";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const STORAGE_KEY = "@pogo_analyzer_recent_scans";
+const MAX_HISTORY = 12;
+const API_BASE_URL =
+  process.env.EXPO_PUBLIC_API_BASE_URL ?? process.env.API_BASE_URL ?? "http://localhost:8000";
+
+type ScanResult = {
+  name: string;
+  form: string;
+  ivs: [number, number, number];
+  level: number;
+};
+
+type ScanHistoryEntry = {
+  id: string;
+  imageUri: string;
+  timestamp: string;
+  result: ScanResult;
+};
+
+const emptyResult: ScanResult | null = null;
+
+const toScanResult = (payload: any): ScanResult => ({
+  name: String(payload?.name ?? ""),
+  form: String(payload?.form ?? ""),
+  ivs: [0, 1, 2].map((index) => Number(payload?.ivs?.[index] ?? 0)) as [
+    number,
+    number,
+    number
+  ],
+  level: Number(payload?.level ?? 0),
+});
+
+const formatTimestamp = (value: string): string => {
+  try {
+    return new Date(value).toLocaleString();
+  } catch (error) {
+    return value;
+  }
+};
+
+const CaptureScreen: React.FC = () => {
+  const [imageUri, setImageUri] = useState<string | null>(null);
+  const [analysis, setAnalysis] = useState<ScanResult | null>(emptyResult);
+  const [history, setHistory] = useState<ScanHistoryEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const bootstrap = async () => {
+      try {
+        const stored = await AsyncStorage.getItem(STORAGE_KEY);
+        if (stored) {
+          const parsed = JSON.parse(stored) as ScanHistoryEntry[];
+          setHistory(parsed);
+        }
+      } catch (error) {
+        console.warn("Failed to load cached scans", error);
+      }
+    };
+
+    void bootstrap();
+  }, []);
+
+  useEffect(() => {
+    const requestPermissions = async () => {
+      const camera = await ImagePicker.requestCameraPermissionsAsync();
+      const media = await ImagePicker.requestMediaLibraryPermissionsAsync();
+      if (camera.status !== "granted" || media.status !== "granted") {
+        Alert.alert(
+          "Permissions required",
+          "Camera and media permissions are needed to analyse screenshots.",
+        );
+      }
+    };
+
+    void requestPermissions();
+  }, []);
+
+  const persistHistory = useCallback((entries: ScanHistoryEntry[]) => {
+    void AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  }, []);
+
+  const capture = useCallback(async () => {
+    const result = await ImagePicker.launchCameraAsync({ quality: 0.8, base64: false });
+    if (result.canceled) {
+      return;
+    }
+
+    const uri = result.assets?.[0]?.uri;
+    if (uri) {
+      setImageUri(uri);
+      setAnalysis(emptyResult);
+    }
+  }, []);
+
+  const pickFromLibrary = useCallback(async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({ quality: 0.8, base64: false });
+    if (result.canceled) {
+      return;
+    }
+    const uri = result.assets?.[0]?.uri;
+    if (uri) {
+      setImageUri(uri);
+      setAnalysis(emptyResult);
+    }
+  }, []);
+
+  const submitForAnalysis = useCallback(async () => {
+    if (!imageUri) {
+      Alert.alert("No screenshot", "Capture or select a screenshot first.");
+      return;
+    }
+
+    const fileName = imageUri.split("/").pop() ?? "screenshot.png";
+    const form = new FormData();
+    form.append(
+      "file",
+      {
+        uri: imageUri,
+        name: fileName,
+        type: "image/png",
+      } as unknown as any,
+    );
+
+    setLoading(true);
+    try {
+      const response = await fetch(`${API_BASE_URL}/scan`, {
+        method: "POST",
+        body: form,
+      });
+
+      if (!response.ok) {
+        const detail = await response.text();
+        throw new Error(detail || "Unable to analyse screenshot.");
+      }
+
+      const payload = await response.json();
+      const parsed = toScanResult(payload);
+      setAnalysis(parsed);
+
+      const entry: ScanHistoryEntry = {
+        id: `${Date.now()}`,
+        imageUri,
+        timestamp: new Date().toISOString(),
+        result: parsed,
+      };
+
+      setHistory((previous) => {
+        const filtered = previous.filter((item) => item.imageUri !== entry.imageUri);
+        const updated = [entry, ...filtered].slice(0, MAX_HISTORY);
+        persistHistory(updated);
+        return updated;
+      });
+    } catch (error: any) {
+      Alert.alert("Analysis failed", error?.message ?? "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  }, [imageUri, persistHistory]);
+
+  const handleSelectHistory = useCallback((entry: ScanHistoryEntry) => {
+    setAnalysis(entry.result);
+    setImageUri(entry.imageUri);
+  }, []);
+
+  const analysisView = useMemo(() => {
+    if (!analysis) {
+      return (
+        <Text style={styles.placeholderText}>
+          Capture or select a screenshot to analyse it.
+        </Text>
+      );
+    }
+
+    const levelDisplay = Number.isFinite(analysis.level)
+      ? analysis.level.toFixed(1)
+      : "?";
+
+    return (
+      <View style={styles.analysisCard}>
+        <Text style={styles.analysisTitle}>{analysis.name}</Text>
+        <Text style={styles.analysisSubtitle}>Form: {analysis.form || "Normal"}</Text>
+        <Text style={styles.analysisDetail}>IVs: {analysis.ivs.join(" / ")}</Text>
+        <Text style={styles.analysisDetail}>Level: {levelDisplay}</Text>
+      </View>
+    );
+  }, [analysis]);
+
+  const renderHistoryItem = useCallback(({ item }: { item: ScanHistoryEntry }) => (
+    <TouchableOpacity
+      onPress={() => handleSelectHistory(item)}
+      style={[styles.historyItem, styles.historyItemSpacing]}
+    >
+      <Image source={{ uri: item.imageUri }} style={styles.historyThumbnail} />
+      <View style={styles.historyTextContainer}>
+        <Text style={styles.historyTitle}>{item.result.name}</Text>
+        <Text style={[styles.historySubtitle, styles.historyTextSpacing]}>
+          {item.result.form || "Normal"}
+        </Text>
+        <Text style={[styles.historyMeta, styles.historyTextSpacing]}>
+          {formatTimestamp(item.timestamp)}
+        </Text>
+      </View>
+    </TouchableOpacity>
+  ), [handleSelectHistory]);
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <ScrollView contentContainerStyle={styles.container}>
+        <View style={styles.previewContainer}>
+          {imageUri ? (
+            <Image source={{ uri: imageUri }} style={styles.previewImage} />
+          ) : (
+            <Text style={styles.placeholderText}>No screenshot selected.</Text>
+          )}
+        </View>
+
+        <View style={styles.buttonRow}>
+          <TouchableOpacity onPress={capture} style={[styles.button, styles.buttonSpacing]}>
+            <Text style={styles.buttonLabel}>Capture</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={pickFromLibrary} style={[styles.button, styles.buttonSpacing]}>
+            <Text style={styles.buttonLabel}>Select</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={submitForAnalysis} style={styles.primaryButton}>
+            {loading ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.primaryButtonLabel}>Analyze</Text>
+            )}
+          </TouchableOpacity>
+        </View>
+
+        <View style={styles.analysisContainer}>{analysisView}</View>
+
+        <Text style={styles.historyHeading}>Recent scans</Text>
+        {history.length === 0 ? (
+          <Text style={styles.placeholderText}>Scans will be cached here for offline review.</Text>
+        ) : (
+          <FlatList
+            data={history}
+            keyExtractor={(item) => item.id}
+            renderItem={renderHistoryItem}
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.historyList}
+          />
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+export default CaptureScreen;
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: "#0f172a",
+  },
+  container: {
+    padding: 16,
+  },
+  previewContainer: {
+    height: 280,
+    borderRadius: 12,
+    backgroundColor: "#1e293b",
+    alignItems: "center",
+    justifyContent: "center",
+    overflow: "hidden",
+  },
+  previewImage: {
+    width: "100%",
+    height: "100%",
+    resizeMode: "cover",
+  },
+  placeholderText: {
+    color: "#cbd5f5",
+    textAlign: "center",
+  },
+  buttonRow: {
+    flexDirection: "row",
+    marginTop: 16,
+  },
+  button: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: "#334155",
+    alignItems: "center",
+  },
+  buttonLabel: {
+    color: "#f8fafc",
+    fontWeight: "600",
+  },
+  primaryButton: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: "#2563eb",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  primaryButtonLabel: {
+    color: "#f8fafc",
+    fontWeight: "700",
+  },
+  analysisContainer: {
+    marginTop: 24,
+    padding: 16,
+    borderRadius: 12,
+    backgroundColor: "#1e293b",
+  },
+  analysisCard: {
+  },
+  analysisTitle: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#f8fafc",
+  },
+  analysisSubtitle: {
+    color: "#cbd5f5",
+    marginTop: 4,
+  },
+  analysisDetail: {
+    color: "#e2e8f0",
+    marginTop: 4,
+  },
+  historyHeading: {
+    marginTop: 24,
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#f8fafc",
+  },
+  historyList: {
+    paddingVertical: 12,
+    paddingRight: 12,
+  },
+  historyItem: {
+    width: 160,
+    backgroundColor: "#1e293b",
+    borderRadius: 12,
+    overflow: "hidden",
+  },
+  historyItemSpacing: {
+    marginRight: 12,
+  },
+  historyThumbnail: {
+    width: "100%",
+    height: 110,
+  },
+  historyTextContainer: {
+    padding: 12,
+  },
+  historyTitle: {
+    fontWeight: "600",
+    color: "#f8fafc",
+  },
+  historySubtitle: {
+    color: "#cbd5f5",
+  },
+  historyMeta: {
+    color: "#94a3b8",
+    fontSize: 12,
+  },
+  historyTextSpacing: {
+    marginTop: 4,
+  },
+  buttonSpacing: {
+    marginRight: 12,
+  },
+});

--- a/src/pogo_analyzer/__init__.py
+++ b/src/pogo_analyzer/__init__.py
@@ -1,6 +1,6 @@
 """Pokémon GO analysis library."""
 
-from . import analysis, calculations, data_loader, events, social, team_builder
+from . import analysis, api, calculations, data_loader, events, social, team_builder
 
 __all__ = [
     "data_loader",
@@ -9,4 +9,5 @@ __all__ = [
     "team_builder",
     "events",
     "social",
+    "api",
 ]

--- a/src/pogo_analyzer/api.py
+++ b/src/pogo_analyzer/api.py
@@ -1,0 +1,99 @@
+"""REST API for exposing :func:`pogo_analyzer.vision.scan_screenshot`."""
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Any, Dict
+
+from .vision import scan_screenshot
+
+try:  # pragma: no cover - optional dependency
+    from fastapi import FastAPI, File, HTTPException, UploadFile
+    from fastapi.encoders import jsonable_encoder
+    from fastapi.responses import JSONResponse
+except Exception:  # pragma: no cover - gracefully handled at runtime
+    FastAPI = None  # type: ignore
+    File = None  # type: ignore
+    HTTPException = None  # type: ignore
+    UploadFile = None  # type: ignore
+    jsonable_encoder = None  # type: ignore
+    JSONResponse = None  # type: ignore
+
+
+_IMAGE_CONTENT_TYPES = {
+    "image/png",
+    "image/jpeg",
+    "image/jpg",
+    "image/webp",
+}
+
+
+def _validate_dependency() -> None:
+    if FastAPI is None:
+        raise RuntimeError(
+            "FastAPI is required to use pogo_analyzer.api. Install fastapi to expose the"
+            " scan endpoint."
+        )
+
+
+def create_app() -> "FastAPI":
+    """Return a configured FastAPI application exposing screenshot analysis."""
+
+    _validate_dependency()
+    assert FastAPI is not None  # for mypy
+
+    app = FastAPI(title="Pokémon Analyzer", version="1.0.0")
+
+    @app.get("/health", tags=["system"])
+    async def healthcheck() -> Dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/scan", tags=["analysis"])
+    async def scan_endpoint(file: UploadFile = File(...)) -> "JSONResponse":  # type: ignore[valid-type]
+        assert UploadFile is not None and JSONResponse is not None and HTTPException is not None
+
+        if file.content_type and file.content_type.lower() not in _IMAGE_CONTENT_TYPES:
+            raise HTTPException(status_code=400, detail="Only image uploads are supported.")
+
+        try:
+            data = await file.read()
+        except Exception as exc:  # pragma: no cover - exercised in error handling tests
+            raise HTTPException(status_code=400, detail=f"Failed to read upload: {exc}") from exc
+
+        if not data:
+            raise HTTPException(status_code=400, detail="Uploaded file is empty.")
+
+        suffix = Path(file.filename or "screenshot").suffix or ".png"
+        tmp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+                tmp.write(data)
+                tmp_path = Path(tmp.name)
+            result = scan_screenshot(tmp_path)
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        finally:
+            if tmp_path is not None and tmp_path.exists():
+                tmp_path.unlink()
+
+        payload: Dict[str, Any]
+        if jsonable_encoder is not None:
+            payload = jsonable_encoder(result)
+        else:  # pragma: no cover - jsonable_encoder always available with FastAPI
+            payload = dict(result)
+            ivs = payload.get("ivs")
+            if isinstance(ivs, tuple):
+                payload["ivs"] = list(ivs)
+
+        return JSONResponse(content=payload)
+
+    return app
+
+
+try:  # pragma: no cover - optional when module imported for app discovery
+    app = create_app()
+except RuntimeError:  # FastAPI missing
+    app = None  # type: ignore
+
+
+__all__ = ["create_app", "app"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from pogo_analyzer import api, vision  # noqa: E402
+
+
+def test_scan_endpoint_returns_analysis(monkeypatch):
+    analysis = {"name": "Bulbasaur", "form": "Normal", "ivs": (10, 11, 12), "level": 20.0}
+    captured_path: Path | None = None
+
+    def fake_scan(path: Path | str):
+        nonlocal captured_path
+        captured_path = Path(path)
+        assert captured_path.exists()
+        return analysis
+
+    monkeypatch.setattr(vision, "scan_screenshot", fake_scan)
+
+    app = api.create_app()
+    client = TestClient(app)
+
+    response = client.post(
+        "/scan",
+        files={"file": ("bulbasaur.png", b"pretend-bytes", "image/png")},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {**analysis, "ivs": [10, 11, 12]}
+    assert captured_path is not None
+    assert not captured_path.exists()
+
+
+def test_scan_endpoint_rejects_non_image(monkeypatch):
+    monkeypatch.setattr(vision, "scan_screenshot", lambda path: {"ok": True})
+
+    app = api.create_app()
+    client = TestClient(app)
+
+    response = client.post(
+        "/scan",
+        files={"file": ("note.txt", b"hello", "text/plain")},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Only image uploads are supported."


### PR DESCRIPTION
## Summary
- add a FastAPI application that exposes the `scan_screenshot` helper along with a health endpoint
- cover the new API with unit tests and export it from the library package
- document the REST workflow and add a React Native capture screen that caches recent analyses for offline review

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c89b0c73008328856c8795d00073b3