### PR TITLE
Fix typing issues uncovered by mypy

### DIFF
--- a/src/pogo_analyzer/analysis.py
+++ b/src/pogo_analyzer/analysis.py
@@ -1,7 +1,7 @@
 """High level Pokémon analysis functions."""
 from __future__ import annotations
 
-from typing import Dict, Tuple
+from typing import Any, Dict, Tuple
 
 from . import data_loader, calculations, events
 from .models import PokemonSpecies, Move
@@ -45,7 +45,7 @@ def analyze_pokemon(
         if event_move_override.get("charged"):
             selected_moves["charged"] = event_move_override["charged"]
 
-    def resolve_move(candidates, fallback):
+    def resolve_move(candidates: Tuple[str, ...] | list[str], fallback: Tuple[str, ...] | list[str]) -> Move:
         for move_name in candidates:
             move = move_data.get(move_name)
             if move is not None:
@@ -60,8 +60,8 @@ def analyze_pokemon(
     charged_move: Move = resolve_move(selected_moves["charged"], moves["charged"])
     pve_bp = calculations.pve_breakpoints(stats, fast_move, boss_def=200)
     pve_sc = calculations.pve_score(stats, {"fast": fast_move, "charged": charged_move})
-    league_caps = dict(data_loader.LEAGUE_CP_CAPS)
-    applied_cp_caps = {}
+    league_caps: Dict[str, int] = dict(data_loader.LEAGUE_CP_CAPS)
+    applied_cp_caps: Dict[str, calculations.EventCapModifier] = {}
     for league, override in event_modifiers.get("cp_caps", {}).items():
         value = override.get("value") if isinstance(override, dict) else override
         if value is None:
@@ -77,7 +77,7 @@ def analyze_pokemon(
         if league in pvp_rec:
             pvp_rec[league]["event_modifier"] = modifier
 
-    event_summary = {
+    event_summary: Dict[str, Any] = {
         "active_events": list(event_modifiers.get("active_events", [])),
         "moves": {},
         "cp_caps": applied_cp_caps,

--- a/src/pogo_analyzer/api.py
+++ b/src/pogo_analyzer/api.py
@@ -8,9 +8,9 @@ from typing import Any, Dict
 from .vision import scan_screenshot
 
 try:  # pragma: no cover - optional dependency
-    from fastapi import FastAPI, File, HTTPException, UploadFile
-    from fastapi.encoders import jsonable_encoder
-    from fastapi.responses import JSONResponse
+    from fastapi import FastAPI, File, HTTPException, UploadFile  # type: ignore[import-not-found]
+    from fastapi.encoders import jsonable_encoder  # type: ignore[import-not-found]
+    from fastapi.responses import JSONResponse  # type: ignore[import-not-found]
 except Exception:  # pragma: no cover - gracefully handled at runtime
     FastAPI = None  # type: ignore
     File = None  # type: ignore

--- a/src/pogo_analyzer/data_loader.py
+++ b/src/pogo_analyzer/data_loader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from .models import PokemonSpecies, Move, CPMultiplier
 
@@ -19,7 +19,7 @@ BEST_BUDDY_LEVEL_BONUS = 1.0
 LEAGUE_CP_CAPS = {"great": 1500, "ultra": 2500, "master": 10000}
 
 
-def _load_json(name: str) -> List[Dict]:
+def _load_json(name: str) -> Any:
     return json.loads((DATA_DIR / name).read_text())
 
 


### PR DESCRIPTION
## Summary
- correct the generic JSON loader typing so dict-based data structures satisfy mypy
- add structured typings for stat calculations and propagate them through the analysis and CLI layers
- silence optional FastAPI import errors and tighten CLI argument casting for static type checking

## Testing
- `mypy src`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8e334b5a883288feb7e4a6d20f859