### PR TITLE
Handle missing pandas gracefully during Excel export

### DIFF
--- a/raid_scoreboard_generator.py
+++ b/raid_scoreboard_generator.py
@@ -425,13 +425,22 @@ def main() -> None:
 
     # Save CSV
     df.to_csv(out_csv, index=False)
-    # Save Excel (requires openpyxl or xlsxwriter installed)
-    try:
-        df.to_excel(out_xlsx, index=False)
-        print("Saved:", out_xlsx.resolve())
-    except Exception as e:
-        # Still consider CSV as the primary artifact if Excel engine is missing
-        print("Warning: failed to write Excel (install openpyxl). Reason:", str(e))
+    # Save Excel (requires pandas with an Excel engine installed)
+    if isinstance(df, SimpleTable) or pd is None:
+        print("Skipped Excel export: install pandas to enable Excel output.")
+    else:
+        try:
+            df.to_excel(out_xlsx, index=False)
+            print("Saved:", out_xlsx.resolve())
+        except Exception as e:
+            reason = str(e)
+            lower_reason = reason.lower()
+            suggestion = ""
+            if "openpyxl" in lower_reason:
+                suggestion = " (install openpyxl)"
+            elif "xlsxwriter" in lower_reason:
+                suggestion = " (install xlsxwriter)"
+            print(f"Warning: failed to write Excel{suggestion}. Reason:", reason)
     print("Saved:", out_csv.resolve())
     print()
     print("Top 10 preview:")

--- a/test.py
+++ b/test.py
@@ -1,1 +1,55 @@
-# Test for PogoAnalyzer
+"""Tests for raid_scoreboard_generator."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import tempfile
+from pathlib import Path
+
+import unittest
+
+import raid_scoreboard_generator as rsg
+
+
+class ChangeDirectory:
+    """Context manager to temporarily switch working directory."""
+
+    def __init__(self, target: Path):
+        self._target = target
+        self._previous: Path | None = None
+
+    def __enter__(self) -> Path:
+        self._previous = Path.cwd()
+        os.chdir(self._target)
+        return self._target
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        if self._previous is not None:
+            os.chdir(self._previous)
+
+
+class RaidScoreboardTests(unittest.TestCase):
+    def test_missing_pandas_skips_excel_export(self) -> None:
+        """Ensure the user guidance is correct when pandas isn't available."""
+
+        original_pd = rsg.pd
+        try:
+            rsg.pd = None
+            with tempfile.TemporaryDirectory() as tmp:
+                output = io.StringIO()
+                with contextlib.redirect_stdout(output):
+                    with ChangeDirectory(Path(tmp)):
+                        rsg.main()
+                out_text = output.getvalue()
+                self.assertIn("pandas", out_text)
+                self.assertNotIn("openpyxl", out_text)
+                self.assertTrue(Path(tmp, "raid_scoreboard.csv").exists())
+                self.assertFalse(Path(tmp, "raid_scoreboard.xlsx").exists())
+        finally:
+            rsg.pd = original_pd
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add regression test covering missing-pandas execution path
- skip Excel export when pandas is unavailable and clarify user guidance
- keep actionable hints for missing Excel engines when pandas is present

## Testing
- python -m unittest

------
https://chatgpt.com/codex/tasks/task_e_68c8e63d1fac8328b1a5d4c0c7ebb61a