### PR TITLE
Harden scan API file handling

### DIFF
--- a/src/pogo_analyzer/api.py
+++ b/src/pogo_analyzer/api.py
@@ -1,31 +1,78 @@
 """REST API for exposing :func:`pogo_analyzer.vision.scan_screenshot`."""
 from __future__ import annotations
 
+import imghdr
 import tempfile
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Tuple
 
 from .vision import scan_screenshot
 
 try:  # pragma: no cover - optional dependency
-    from fastapi import FastAPI, File, HTTPException, UploadFile  # type: ignore[import-not-found]
+    from fastapi import FastAPI, File, HTTPException, Request, UploadFile  # type: ignore[import-not-found]
     from fastapi.encoders import jsonable_encoder  # type: ignore[import-not-found]
     from fastapi.responses import JSONResponse  # type: ignore[import-not-found]
 except Exception:  # pragma: no cover - gracefully handled at runtime
     FastAPI = None  # type: ignore
     File = None  # type: ignore
     HTTPException = None  # type: ignore
+    Request = None  # type: ignore
     UploadFile = None  # type: ignore
     jsonable_encoder = None  # type: ignore
     JSONResponse = None  # type: ignore
 
 
 _IMAGE_CONTENT_TYPES = {
-    "image/png",
-    "image/jpeg",
-    "image/jpg",
-    "image/webp",
+    "image/png": "png",
+    "image/jpeg": "jpeg",
+    "image/jpg": "jpeg",
+    "image/webp": "webp",
 }
+
+_ALLOWED_IMAGE_FORMATS: Dict[str, str] = {
+    "png": ".png",
+    "jpeg": ".jpg",
+    "webp": ".webp",
+}
+
+_MAX_UPLOAD_SIZE_MB = 5
+_MAX_UPLOAD_SIZE = _MAX_UPLOAD_SIZE_MB * 1024 * 1024
+
+_SECURE_HEADERS: Dict[str, str] = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "no-referrer",
+    "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+    "Content-Security-Policy": "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'",
+}
+
+
+def _validate_image_upload(data: bytes, *, declared_type: str) -> Tuple[str, str]:
+    """Validate the uploaded image payload and return the detected format and suffix."""
+
+    assert HTTPException is not None  # pragma: no cover - ensured by dependency validation
+
+    if len(data) > _MAX_UPLOAD_SIZE:
+        raise HTTPException(
+            status_code=413,
+            detail=f"Uploaded file exceeds {_MAX_UPLOAD_SIZE_MB} MB limit.",
+        )
+
+    detected_format = imghdr.what(None, data)
+    if detected_format is None or detected_format not in _ALLOWED_IMAGE_FORMATS:
+        raise HTTPException(
+            status_code=400,
+            detail="Unsupported or corrupted image upload.",
+        )
+
+    expected_format = _IMAGE_CONTENT_TYPES.get(declared_type)
+    if expected_format and detected_format != expected_format:
+        raise HTTPException(
+            status_code=400,
+            detail="Uploaded file content does not match declared image type.",
+        )
+
+    return detected_format, _ALLOWED_IMAGE_FORMATS[detected_format]
 
 
 def _validate_dependency() -> None:
@@ -44,6 +91,15 @@ def create_app() -> "FastAPI":
 
     app = FastAPI(title="Pokémon Analyzer", version="1.0.0")
 
+    assert Request is not None  # for mypy
+
+    @app.middleware("http")
+    async def add_security_headers(request: "Request", call_next):  # type: ignore[override]
+        response = await call_next(request)
+        for header, value in _SECURE_HEADERS.items():
+            response.headers.setdefault(header, value)
+        return response
+
     @app.get("/health", tags=["system"])
     async def healthcheck() -> Dict[str, str]:
         return {"status": "ok"}
@@ -52,9 +108,10 @@ def create_app() -> "FastAPI":
     async def scan_endpoint(file: UploadFile = File(...)) -> "JSONResponse":  # type: ignore[valid-type]
         assert UploadFile is not None and JSONResponse is not None and HTTPException is not None
 
-        if file.content_type and file.content_type.lower() not in _IMAGE_CONTENT_TYPES:
+        if not file.content_type or file.content_type.lower() not in _IMAGE_CONTENT_TYPES:
             raise HTTPException(status_code=400, detail="Only image uploads are supported.")
 
+        declared_type = file.content_type.lower()
         try:
             data = await file.read()
         except Exception as exc:  # pragma: no cover - exercised in error handling tests
@@ -63,7 +120,7 @@ def create_app() -> "FastAPI":
         if not data:
             raise HTTPException(status_code=400, detail="Uploaded file is empty.")
 
-        suffix = Path(file.filename or "screenshot").suffix or ".png"
+        _, suffix = _validate_image_upload(data, declared_type=declared_type)
         tmp_path: Path | None = None
         try:
             with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,11 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 from pogo_analyzer import api, vision  # noqa: E402
 
+PNG_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+    b"\x00\x00\x00\nIDATx\x9cc````\x00\x00\x00\x04\x00\x01\xe2!\xbc3\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
 
 def test_scan_endpoint_returns_analysis(monkeypatch):
     analysis = {"name": "Bulbasaur", "form": "Normal", "ivs": (10, 11, 12), "level": 20.0}
@@ -28,7 +33,7 @@ def test_scan_endpoint_returns_analysis(monkeypatch):
 
     response = client.post(
         "/scan",
-        files={"file": ("bulbasaur.png", b"pretend-bytes", "image/png")},
+        files={"file": ("bulbasaur.png", PNG_BYTES, "image/png")},
     )
 
     assert response.status_code == 200
@@ -50,3 +55,46 @@ def test_scan_endpoint_rejects_non_image(monkeypatch):
 
     assert response.status_code == 400
     assert response.json()["detail"] == "Only image uploads are supported."
+
+
+def test_scan_endpoint_rejects_large_upload(monkeypatch):
+    monkeypatch.setattr(vision, "scan_screenshot", lambda path: {"ok": True})
+
+    app = api.create_app()
+    client = TestClient(app)
+
+    oversized = PNG_BYTES + b"0" * (api._MAX_UPLOAD_SIZE + 1)
+    response = client.post(
+        "/scan",
+        files={"file": ("bulky.png", oversized, "image/png")},
+    )
+
+    assert response.status_code == 413
+    assert "exceeds" in response.json()["detail"]
+
+
+def test_scan_endpoint_rejects_corrupted_image(monkeypatch):
+    monkeypatch.setattr(vision, "scan_screenshot", lambda path: {"ok": True})
+
+    app = api.create_app()
+    client = TestClient(app)
+
+    response = client.post(
+        "/scan",
+        files={"file": ("fake.png", b"not-a-real-image", "image/png")},
+    )
+
+    assert response.status_code == 400
+    assert "Unsupported" in response.json()["detail"]
+
+
+def test_security_headers_present():
+    app = api.create_app()
+    client = TestClient(app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["X-Frame-Options"] == "DENY"
+    assert response.headers["Content-Security-Policy"].startswith("default-src 'none'")


### PR DESCRIPTION
## Summary
- enforce strict image type detection and size limits on scan uploads
- add security headers middleware to the FastAPI app
- extend API tests for oversized and corrupt uploads plus header coverage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8ed149b988328bc1a95d3e7bafa7d