### PR TITLE
Revamp documentation and clarify API usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+Thanks for your interest in improving PoGo Analyzer! This guide explains how to set up your environment, submit changes, and keep the tooling consistent.
+
+## Development setup
+
+1. Fork and clone the repository.
+2. Create a virtual environment and install optional tooling:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install --upgrade pip
+   pip install pandas openpyxl  # optional, enables Excel exports during testing
+   ```
+
+3. Install any additional tooling you prefer (e.g., `black`, `ruff`, `mypy`) for local linting. The repository does not currently enforce a specific formatter, but PEP 8 style is encouraged.
+
+## Making changes
+
+- **Tests first** – update or add unit tests alongside your changes. Run `python -m unittest` before opening a pull request.
+- **Document behavior** – keep README, API docs, and docstrings in sync with the code. Include runnable examples whenever possible.
+- **Coding style** – favour clear naming, small functions, and descriptive docstrings. Avoid adding pandas-only constructs inside the core package so scripts remain usable without optional dependencies.
+- **Data updates** – when editing `pogo_analyzer/raid_entries.py`, make sure notes explain any special move requirements or mega considerations so readers understand the resulting score.
+
+## Pull requests
+
+1. Create a descriptive branch name (e.g., `feature/add-shadow-support`).
+2. Keep commits focused and include concise commit messages describing _what_ changed and _why_.
+3. Link to related issues or discussions in the pull request description when applicable.
+4. Confirm the automated checks pass. Include the command output in your PR description if CI is unavailable.
+5. Request review from maintainers or other contributors.
+
+## Reporting issues
+
+When filing a bug report or feature request, include:
+
+- Current behavior and the expected result
+- Steps to reproduce (commands, input files, etc.)
+- Environment details (OS, Python version, whether pandas is installed)
+- Screenshots or logs if helpful
+
+We appreciate thoughtful, actionable feedback—thanks again for contributing!

--- a/README.md
+++ b/README.md
@@ -1,0 +1,95 @@
+# PoGo Analyzer
+
+PoGo Analyzer is a lightweight toolkit for evaluating Pokémon GO raid investments. It ships with a ready-to-run scoreboard generator that grades your Pokémon on a 1–100 scale and exports the results as CSV (and Excel when pandas is available). All functionality is implemented in pure Python so you can run the scripts anywhere, with optional pandas support for richer tabular output.
+
+## Features
+
+- 📊 **Raid value scoreboard** – score your roster by combining baseline species strength, IV quality, lucky cost savings, move requirements, and mega availability.
+- 🧮 **Reusable scoring helpers** – import the library to compute raid scores or transform entries inside your own automation scripts.
+- 🗃️ **Pandas-free tables** – fall back to a minimal in-repo table implementation when pandas is not installed.
+- 🧪 **Tested behavior** – regression tests cover key scoring, formatting, and export scenarios.
+
+## Requirements
+
+- Python 3.9 or newer
+- Optional: [pandas](https://pandas.pydata.org/) plus an Excel writer (``openpyxl`` or ``xlsxwriter``) for `.xlsx` export
+
+## Installation
+
+Clone the repository and install the optional dependencies when you want Excel output:
+
+```bash
+git clone https://github.com/<your-user>/pogo-analyzer.git
+cd pogo-analyzer
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt  # if you create one, otherwise install pandas manually
+```
+
+If you only need the CSV output, you can skip installing pandas entirely.
+
+## Quick start
+
+1. Add or adjust your Pokémon entries in [`pogo_analyzer/raid_entries.py`](pogo_analyzer/raid_entries.py).
+2. Run the scoreboard generator:
+
+   ```bash
+   python raid_scoreboard_generator.py
+   ```
+
+3. Inspect the generated files in the project root:
+   - `raid_scoreboard.csv` – always produced
+   - `raid_scoreboard.xlsx` – requires pandas with an Excel engine
+
+The script also prints a preview of the top ten entries to standard output.
+
+### Library usage
+
+Import the package if you want to automate scoring in another script or notebook:
+
+```python
+from pogo_analyzer import PokemonRaidEntry, build_rows, SimpleTable, raid_score
+
+entries = [
+    PokemonRaidEntry(
+        "Hydreigon",
+        (15, 14, 15),
+        final_form="Hydreigon (Brutal Swing)",
+        role="Dark DPS",
+        base=88,
+        needs_tm=True,
+        notes="Top-tier Dark attacker with its Community Day move.",
+    )
+]
+
+rows = build_rows(entries)
+# Use pandas when available; SimpleTable otherwise.
+table = SimpleTable(rows)
+table = table.sort_values(by="Raid Score (1-100)", ascending=False)
+print(table.to_string(index=False))
+```
+
+### Exporting without pandas
+
+When pandas is unavailable the scripts transparently fall back to `SimpleTable`. You still receive a CSV file and console preview. Attempting to export Excel without pandas prints a friendly warning along with suggestions for installing an engine such as `openpyxl`.
+
+## Updating the dataset
+
+Each raid entry is defined via the [`PokemonRaidEntry`](docs/api.md#pokemonraidentry) dataclass. Supply the Pokémon's name, IV spread, baseline rating, and any flags that affect the computed score. The [`docs/api.md`](docs/api.md) reference includes a full parameter breakdown and scoring formula.
+
+## Testing
+
+Run the unit tests whenever you change scoring logic or table utilities:
+
+```bash
+python -m unittest
+```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for pull request, coding-style, and documentation guidelines.
+
+## License
+
+This project inherits the license of the upstream repository. Add a LICENSE file if you plan to distribute your own fork.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,148 @@
+# API reference
+
+This document highlights the public entry points exposed by PoGo Analyzer. All examples are runnable with Python 3.9+ and assume you are working from the repository root.
+
+## Module: `raid_scoreboard_generator`
+
+| Symbol | Description |
+| ------ | ----------- |
+| `build_dataframe(entries: Sequence[PokemonRaidEntry] = RAID_ENTRIES)` | Convert a sequence of raid entries into either a `pandas.DataFrame` (when pandas is installed) or a [`SimpleTable`](#module-pogo_analyzersimple_table). |
+| `add_priority_tier(df)` | Add a `"Priority Tier"` column derived from the computed raid score. Works with both DataFrame and SimpleTable instances. |
+| `main()` | Command-line entry point. Builds the table, writes CSV/Excel files, and prints a preview. |
+
+### Building a scoreboard programmatically
+
+```python
+from raid_scoreboard_generator import (
+    PokemonRaidEntry,
+    build_dataframe,
+    add_priority_tier,
+)
+
+def preview(entries):
+    df = build_dataframe(entries)
+    df = df.sort_values(by="Raid Score (1-100)", ascending=False)
+    df = add_priority_tier(df)
+    print(df.head(5).to_string(index=False))
+
+preview([
+    PokemonRaidEntry(
+        "Rayquaza",
+        (15, 14, 15),
+        final_form="Mega Rayquaza",
+        role="Dragon/Flying DPS",
+        base=95,
+        mega_now=True,
+        notes="Near-maximum raid score thanks to overwhelming DPS and mega utility.",
+    )
+])
+```
+
+## Module: `pogo_analyzer.raid_entries`
+
+### `PokemonRaidEntry`
+
+Immutable dataclass representing one row on the raid scoreboard.
+
+| Field | Type | Purpose |
+| ----- | ---- | ------- |
+| `name` | `str` | Nickname or identifier shown in the table. |
+| `ivs` | `tuple[int, int, int]` | Attack, Defence, Stamina IVs. Attack carries the greatest weight in the final score. |
+| `final_form` | `str` | Evolutions or mega forms you intend to build. |
+| `role` | `str` | Short description of the Pokémon's raid role (e.g., `"Fighting DPS"`). |
+| `base` | `float` | Baseline score for the species before modifiers. Typical values range from 55–95. |
+| `lucky` | `bool` | Adds +3 to the raid score to reflect reduced dust costs. |
+| `shadow` | `bool` | Indicates the Pokémon is a Shadow variant. Used for labelling only—the damage boost is baked into the baseline score you provide. |
+| `needs_tm` | `bool` | Subtracts 2 points when a Community Day or Elite TM move is required. |
+| `mega_now` | `bool` | Adds +4 points when a relevant mega evolution is currently available. |
+| `mega_soon` | `bool` | Adds +1 point when a mega evolution is confirmed but not yet released. |
+| `notes` | `str` | Free-form explanation shown in the scoreboard. |
+
+Convenience methods:
+
+- `formatted_name()` – Append `(lucky)` and `(shadow)` labels when relevant.
+- `iv_text()` – Render the IV tuple as `"15/14/13"`.
+- `mega_text()` – Display `"Yes"`, `"Soon"`, or `"No"` for mega availability.
+- `move_text()` – Return `"Yes"` when special moves are needed.
+- `as_row()` – Produce a `dict[str, Any]` matching the scoreboard column schema.
+
+#### Building rows manually
+
+```python
+from pogo_analyzer.raid_entries import PokemonRaidEntry, build_rows
+from pogo_analyzer.scoring import iv_bonus
+
+entry = PokemonRaidEntry(
+    "Kartana",
+    (15, 15, 15),
+    final_form="Kartana",
+    role="Grass DPS",
+    base=94,
+    notes="One of the strongest Grass attackers even without mega support.",
+)
+
+rows = build_rows([entry])
+score = rows[0]["Raid Score (1-100)"]
+print("Computed score:", score)
+print("IV bonus portion:", iv_bonus(*entry.ivs))
+```
+
+## Module: `pogo_analyzer.scoring`
+
+- `iv_bonus(a: int, d: int, s: int) -> float` – Calculate the additive IV modifier with Attack weighted ×2 and Defence/Stamina weighted ×0.5. The return value is rounded to two decimal places (maximum of roughly 3.0).
+- `raid_score(base: float, ivb: float = 0.0, *, lucky: bool = False, needs_tm: bool = False, mega_bonus_now: bool = False, mega_bonus_soon: bool = False) -> float` – Combine the baseline score, IV bonus, and optional modifiers. Results are clamped to the inclusive range [1, 100].
+
+### Reproducing the score used in the dataset
+
+```python
+from pogo_analyzer.raid_entries import RAID_ENTRIES
+from pogo_analyzer.scoring import iv_bonus, raid_score
+
+first = RAID_ENTRIES[0]
+attack, defence, stamina = first.ivs
+computed = raid_score(
+    first.base,
+    iv_bonus(attack, defence, stamina),
+    lucky=first.lucky,
+    needs_tm=first.needs_tm,
+    mega_bonus_now=first.mega_now,
+    mega_bonus_soon=first.mega_soon,
+)
+assert computed == first.as_row()["Raid Score (1-100)"]
+```
+
+## Module: `pogo_analyzer.simple_table`
+
+A dependency-free subset of the `pandas.DataFrame` API. Returned when pandas is unavailable.
+
+### `SimpleSeries`
+
+- `SimpleSeries(data)` – Create a wrapper around an iterable.
+- `apply(func)` – Return a new `SimpleSeries` with `func` applied to each element.
+- `to_list()` – Materialise the series as a list.
+- Standard Python iteration (`for value in series`) is supported.
+
+### `SimpleTable`
+
+- `SimpleTable(rows, columns=None)` – Construct a table from a list of dictionaries. Missing values default to empty strings. When `columns` is omitted, headers are discovered from the supplied rows in order of first appearance.
+- `sort_values(by, ascending=True)` – Return a new table sorted by the provided column.
+- `reset_index(drop=False)` – Mirror `pandas.DataFrame.reset_index`. When `drop=False`, an `index` column is added.
+- `__getitem__(column)` – Provide a `SimpleSeries` for compatibility with pandas' column access.
+- `__setitem__(column, values)` – Add or overwrite a column. Accepts iterables or other `SimpleSeries` instances.
+- `to_csv(path, index=False)` – Persist the table as UTF-8 CSV.
+- `to_excel(path, index=False)` – Raise `RuntimeError`; included for parity with pandas.
+- `head(n)` – Return the first `n` rows.
+- `to_string(index=True)` – Render a padded table string for console previews.
+
+```python
+from pogo_analyzer.simple_table import SimpleTable
+
+rows = [
+    {"Name": "Shadow Mamoswine", "Raid Score (1-100)": 91.2},
+    {"Name": "Mega Gengar", "Raid Score (1-100)": 94.5},
+]
+
+preview = SimpleTable(rows).to_string(index=False)
+print(preview)
+```
+

--- a/pogo_analyzer/scoring.py
+++ b/pogo_analyzer/scoring.py
@@ -1,11 +1,31 @@
-"""Scoring helpers shared between the raid scoreboard scripts."""
+"""Helpers for converting raid evaluation heuristics into numeric scores.
+
+The helpers are intentionally light-weight so they can be reused by
+``raid_scoreboard_generator`` and any third-party automation without pulling
+in heavy dependencies.
+"""
 
 from __future__ import annotations
 
 
 def iv_bonus(a: int, d: int, s: int) -> float:
-    """Light-touch IV bonus for raids; Attack weighted more."""
-    return round((a / 15) * 2.0 + (d / 15) * 0.5 + (s / 15) * 0.5, 2)  # max ~3.0
+    """Return the additive IV modifier used by :func:`raid_score`.
+
+    Parameters
+    ----------
+    a, d, s:
+        Attack, Defence, and Stamina IV values (0–15). Attack contributes the
+        majority of the bonus because raid damage scales with Attack.
+
+    Returns
+    -------
+    float
+        The rounded IV contribution, capped at roughly ``3.0`` for perfect IVs.
+    """
+
+    # Weight Attack twice as heavily as Defence/Stamina to reflect raid damage
+    # breakpoints, then round to mimic the original spreadsheet heuristics.
+    return round((a / 15) * 2.0 + (d / 15) * 0.5 + (s / 15) * 0.5, 2)
 
 
 def raid_score(
@@ -17,7 +37,33 @@ def raid_score(
     mega_bonus_now: bool = False,
     mega_bonus_soon: bool = False,
 ) -> float:
-    """Aggregate score with bounded range [1, 100]."""
+    """Combine baseline species strength and modifiers into a raid score.
+
+    Parameters
+    ----------
+    base:
+        Baseline score for the Pokémon's best raid role. Values typically range
+        from the low 50s (poor raiders) to mid 90s (top-tier megas/shadows).
+    ivb:
+        Output from :func:`iv_bonus`. Defaults to ``0.0`` when IVs are
+        unavailable or intentionally ignored.
+    lucky:
+        Adds ``+3`` when the Pokémon is lucky and therefore cheaper to build.
+    needs_tm:
+        Subtracts ``2`` when a Community Day or Elite TM move is mandatory.
+    mega_bonus_now:
+        Adds ``+4`` when the Pokémon currently has a relevant mega evolution
+        unlocked.
+    mega_bonus_soon:
+        Adds ``+1`` when a relevant mega evolution has been announced but is
+        not yet available.
+
+    Returns
+    -------
+    float
+        Final raid score rounded to one decimal place and clamped to ``[1, 100]``.
+    """
+
     sc = base + ivb
     if lucky:
         sc += 3

--- a/pogo_analyzer/simple_table.py
+++ b/pogo_analyzer/simple_table.py
@@ -1,4 +1,10 @@
-"""Minimal table structures that emulate a subset of pandas' interface."""
+"""Minimal table structures that emulate a subset of pandas' interface.
+
+The goal is API compatibility with the portions of ``pandas.DataFrame`` that the
+scoreboard scripts rely on—mainly sorting, indexing, CSV export, and string
+representation. When pandas is installed the real DataFrame is used instead, so
+``SimpleTable`` purposefully keeps the surface area small and predictable.
+"""
 
 from __future__ import annotations
 
@@ -10,15 +16,21 @@ Row = Dict[str, Any]
 
 
 class SimpleSeries:
-    """Minimal ``pandas.Series`` stand-in used when pandas is unavailable."""
+    """Minimal :class:`pandas.Series` stand-in used when pandas is unavailable."""
 
     def __init__(self, data: Iterable[Any]):
+        """Materialise the provided iterable so repeated iteration is safe."""
+
         self._data = list(data)
 
     def apply(self, func: Callable[[Any], Any]) -> "SimpleSeries":
+        """Return a new series with ``func`` applied to each element."""
+
         return SimpleSeries(func(item) for item in self._data)
 
     def to_list(self) -> List[Any]:
+        """Return the series contents as a list copy."""
+
         return list(self._data)
 
     def __iter__(self) -> Iterator[Any]:
@@ -32,11 +44,25 @@ class SimpleTable:
     """Lightweight, pandas-like table to keep scripts functional without pandas."""
 
     def __init__(self, rows: Sequence[Row], columns: Sequence[str] | None = None):
+        """Normalise row data and column order.
+
+        Parameters
+        ----------
+        rows:
+            Sequence of dictionaries representing table rows. Missing keys are
+            filled with empty strings.
+        columns:
+            Optional explicit column order. Unlisted keys discovered in ``rows``
+            are appended so that no data is dropped.
+        """
+
         self._rows = [dict(row) for row in rows]
         discovered_columns: List[str] = []
         discovered_set: set[str] = set()
         for row in self._rows:
             for key in row.keys():
+                # Preserve discovery order so generated tables match pandas'
+                # column ordering when fed the same dictionaries.
                 if key not in discovered_set:
                     discovered_columns.append(key)
                     discovered_set.add(key)
@@ -56,11 +82,19 @@ class SimpleTable:
                 row.setdefault(column, "")
 
     def sort_values(self, by: str, ascending: bool = True) -> "SimpleTable":
+        """Return a table sorted by ``by``; mirrors ``DataFrame.sort_values``."""
+
         reverse = not ascending
         sorted_rows = sorted(self._rows, key=lambda item: item.get(by), reverse=reverse)
         return SimpleTable(sorted_rows, self._columns)
 
     def reset_index(self, drop: bool = False) -> "SimpleTable":
+        """Return a table with a reset positional index.
+
+        When ``drop`` is ``False`` (the default) a new ``index`` column is
+        prepended to mimic pandas' behaviour.
+        """
+
         if drop:
             return SimpleTable(self._rows, self._columns)
         indexed_rows: List[Row] = []
@@ -72,9 +106,13 @@ class SimpleTable:
         return SimpleTable(indexed_rows, columns)
 
     def __getitem__(self, key: str) -> SimpleSeries:
+        """Return a :class:`SimpleSeries` for the requested column."""
+
         return SimpleSeries(row.get(key, "") for row in self._rows)
 
     def __setitem__(self, key: str, value: Iterable[Any]) -> None:
+        """Assign ``value`` to ``key``, matching ``pandas.DataFrame`` semantics."""
+
         if isinstance(value, SimpleSeries):
             values = value.to_list()
         else:
@@ -88,18 +126,26 @@ class SimpleTable:
             self._column_set.add(key)
 
     def to_csv(self, path: Path, index: bool = False) -> None:  # noqa: ARG002 - parity with pandas signature
+        """Write the table to ``path`` in UTF-8 CSV format."""
+
         with Path(path).open("w", newline="", encoding="utf-8") as handle:
             writer = csv.DictWriter(handle, fieldnames=self._columns)
             writer.writeheader()
             writer.writerows(self._rows)
 
     def to_excel(self, path: Path, index: bool = False) -> None:  # noqa: ARG002 - parity with pandas signature
+        """Mimic ``DataFrame.to_excel`` but raise when pandas is absent."""
+
         raise RuntimeError("Excel export requires pandas to be installed.")
 
     def head(self, n: int) -> "SimpleTable":
+        """Return the first ``n`` rows, similar to ``DataFrame.head``."""
+
         return SimpleTable(self._rows[:n], self._columns)
 
     def to_string(self, index: bool = True) -> str:
+        """Render the table as a string suitable for console previews."""
+
         if not self._rows:
             return ""
         columns = list(self._columns)

--- a/raid_scoreboard_generator.py
+++ b/raid_scoreboard_generator.py
@@ -1,21 +1,10 @@
 """
-Raid Scoreboard Generator
--------------------------
-This script builds a sortable raid value scoreboard for your listed Pokémon,
-scoring each entry on a 1–100 scale based on:
-- Species baseline (final raid form & meta placement)
-- IV contribution (Atk-weighted for raids)
-- Lucky cost efficiency
-- Move requirements (Community Day / Elite TM)
-- Mega availability (now/soon) for team boost utility
+Generate a ranked raid scoreboard from curated Pokémon entries.
 
-Outputs:
-- Console preview (head of table)
-- CSV at ./raid_scoreboard.csv with full data
-- Excel at ./raid_scoreboard.xlsx with full data
-
-Notes:
-- This is a guide heuristic, not a simulator. Use it to set priorities quickly.
+The script mirrors the heuristics used in the original spreadsheet-based
+workflow and produces the same set of columns regardless of whether pandas is
+installed. Invoke :func:`main` directly or import the helper functions into your
+own scripts for more control over data filtering and presentation.
 """
 
 from __future__ import annotations
@@ -37,19 +26,36 @@ score = raid_score
 
 
 def _as_table(rows: Sequence[Row]):
+    """Return a pandas DataFrame or :class:`SimpleTable` depending on availability."""
+
     if pd is not None:
         return pd.DataFrame(rows)
     return SimpleTable(rows)
 
 
 def build_dataframe(entries: Sequence[PokemonRaidEntry] = RAID_ENTRIES):
-    """Construct a table for the provided raid entries."""
+    """Construct a tabular object from raid entries.
+
+    Parameters
+    ----------
+    entries:
+        Iterable of :class:`PokemonRaidEntry` instances. Defaults to the bundled
+        dataset but you can supply your own selection to customise the output.
+
+    Returns
+    -------
+    DataFrame | SimpleTable
+        ``pandas.DataFrame`` when pandas is installed, otherwise
+        :class:`~pogo_analyzer.simple_table.SimpleTable`.
+    """
 
     rows = build_rows(entries)
     return _as_table(rows)
 
 
 def add_priority_tier(df):
+    """Append a human-readable priority tier based on ``Raid Score (1-100)``."""
+
     def tier(x: float) -> str:
         if x >= 90:
             return "S (Build ASAP)"
@@ -66,6 +72,8 @@ def add_priority_tier(df):
 
 
 def main() -> None:
+    """Command-line entry point for generating raid scoreboard exports."""
+
     df = build_dataframe()
     df = df.sort_values(by="Raid Score (1-100)", ascending=False).reset_index(drop=True)
     df = add_priority_tier(df)

--- a/test.py
+++ b/test.py
@@ -115,6 +115,31 @@ class RaidScoreboardTests(unittest.TestCase):
         self.assertEqual(data_row["Final Raid Form"], "Final")
         self.assertEqual(data_row["Primary Role"], "Utility")
 
+    def test_add_priority_tier_assigns_expected_labels(self) -> None:
+        """Threshold boundaries should map onto documented priority tiers."""
+
+        table = rsg.SimpleTable(
+            [
+                {"Raid Score (1-100)": 90.0},
+                {"Raid Score (1-100)": 86.0},
+                {"Raid Score (1-100)": 78.0},
+                {"Raid Score (1-100)": 70.0},
+                {"Raid Score (1-100)": 65.0},
+            ]
+        )
+        tiered = rsg.add_priority_tier(table)
+        tiers = [row["Priority Tier"] for row in tiered._rows]  # type: ignore[attr-defined]
+        self.assertEqual(
+            tiers,
+            [
+                "S (Build ASAP)",
+                "A (High)",
+                "B (Good)",
+                "C (Situational)",
+                "D (Doesn't belong on a Raids list)",
+            ],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- rewrite README and CONTRIBUTING to provide setup guidance, runnable examples, and contributor expectations
- add docs/api.md to document the public modules, dataclasses, and helper functions with copy-pastable snippets
- expand docstrings/inline comments across the scoring, raid entry, and table helpers plus add a unit test for priority tier labels

## Testing
- python -m unittest

------
https://chatgpt.com/codex/tasks/task_e_68c95d7325b88328ad1e2d4ad42f0a40