### PR TITLE
Add packaging metadata and CLI entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ PoGo Analyzer is a lightweight toolkit for evaluating Pokémon GO raid investmen
 
 ## Installation
 
-Clone the repository and install the optional dependencies when you want Excel output:
+Clone the repository and install the package into your virtual environment:
 
 ```bash
 git clone https://github.com/<your-user>/pogo-analyzer.git
@@ -24,10 +24,12 @@ cd pogo-analyzer
 python -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip
-pip install -r requirements.txt  # if you create one, otherwise install pandas manually
+pip install .
+# Enable Excel exports with pandas and openpyxl
+pip install .[pandas]
 ```
 
-If you only need the CSV output, you can skip installing pandas entirely.
+If you only need the CSV output, you can skip installing the optional ``[pandas]`` extra.
 
 ## Quick start
 
@@ -35,7 +37,7 @@ If you only need the CSV output, you can skip installing pandas entirely.
 2. Run the scoreboard generator:
 
    ```bash
-   python raid_scoreboard_generator.py
+   pogo-raid-scoreboard
    ```
 
    Use ``--output-dir``/``--csv-name``/``--excel-name`` to customise export

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,40 @@
+[build-system]
+requires = [
+    "setuptools>=69",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pogo-analyzer"
+version = "0.1.0"
+description = "Pokémon GO raid scoring utilities and scoreboard generator."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { file = "LICENSE" }
+authors = [
+    { name = "PoGo Analyzer Contributors" },
+]
+dependencies = []
+
+[project.optional-dependencies]
+pandas = [
+    "pandas>=2.0",
+    "openpyxl>=3.1",
+]
+
+[project.scripts]
+pogo-raid-scoreboard = "raid_scoreboard_generator:main"
+
+[tool.setuptools]
+py-modules = [
+    "raid_scoreboard_generator",
+    "microbench_simple_table",
+]
+
+[tool.setuptools.packages.find]
+include = ["pogo_analyzer*"]
+
 [tool.black]
 line-length = 88
 target-version = ["py39"]

--- a/tests/test_pyproject_metadata.py
+++ b/tests/test_pyproject_metadata.py
@@ -1,0 +1,43 @@
+"""Verify packaging metadata exposes the expected CLI and optional extras."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+try:  # Python 3.11+
+    import tomllib as toml_loader
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback.
+    import tomli as toml_loader  # type: ignore[no-redef]
+
+
+@pytest.fixture(scope="module")
+def pyproject_data() -> dict[str, object]:
+    """Return the parsed ``pyproject.toml`` dictionary for assertions."""
+
+    path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with path.open("rb") as stream:
+        return toml_loader.load(stream)
+
+
+def test_console_script_entry(pyproject_data: dict[str, object]) -> None:
+    """The project should publish the raid scoreboard CLI entry point."""
+
+    project = pyproject_data["project"]
+    assert isinstance(project, dict)
+    scripts = project.get("scripts")
+    assert isinstance(scripts, dict)
+    assert scripts.get("pogo-raid-scoreboard") == "raid_scoreboard_generator:main"
+
+
+def test_pandas_optional_dependency(pyproject_data: dict[str, object]) -> None:
+    """Excel exports should be declared under the pandas optional dependency group."""
+
+    project = pyproject_data["project"]
+    assert isinstance(project, dict)
+    optional = project.get("optional-dependencies")
+    assert isinstance(optional, dict)
+    pandas_deps = optional.get("pandas")
+    assert isinstance(pandas_deps, list)
+    assert {"pandas>=2.0", "openpyxl>=3.1"}.issubset(set(pandas_deps))


### PR DESCRIPTION
## Summary
- add PEP 621 project metadata with build requirements, optional pandas extra, and console script export
- ensure setuptools discovers package modules and include a regression test for the pyproject settings
- document local installation steps and new pogo-raid-scoreboard CLI in the README

## Testing
- `pytest`
- `pip install --force-reinstall .`
- `pogo-raid-scoreboard --help | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68c972e24dd0832893212e3ab0aff576