### PR TITLE
Add CI workflow with linting and testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint-test:
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ruff black mypy pytest
+          python -m pip install .
+          python -m pip install -r requirements.txt
+
+      - name: Run ruff
+        run: ruff check .
+
+      - name: Run black
+        run: black --check .
+
+      - name: Run mypy
+        run: mypy .
+
+      - name: Run pytest
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # PoGo Analyzer
 
+[![CI](https://github.com/pogo-analyzer/pogo-analyzer/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/pogo-analyzer/pogo-analyzer/actions/workflows/ci.yml)
+[![CI – Linux/macOS/Windows](https://img.shields.io/github/actions/workflow/status/pogo-analyzer/pogo-analyzer/ci.yml?branch=main&label=Linux%2FmacOS%2FWindows)](https://github.com/pogo-analyzer/pogo-analyzer/actions/workflows/ci.yml)
+[![CI – Python 3.9–3.12](https://img.shields.io/github/actions/workflow/status/pogo-analyzer/pogo-analyzer/ci.yml?branch=main&label=Python%203.9%E2%80%933.12)](https://github.com/pogo-analyzer/pogo-analyzer/actions/workflows/ci.yml)
+
 PoGo Analyzer is a lightweight toolkit for evaluating Pokémon GO raid investments. It ships with a ready-to-run scoreboard generator that grades your Pokémon on a 1–100 scale and exports the results as CSV (and Excel when pandas is available). All functionality is implemented in pure Python so you can run the scripts anywhere, with optional pandas support for richer tabular output.
 
 ## Features


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs ruff, black --check, mypy, and pytest on Python 3.9 through 3.12 across Linux, macOS, and Windows
- enable pip dependency caching to speed up repeated workflow runs
- surface workflow status badges in the README for quick visibility into build health

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c97967b38883289095d27ecb7c856b