### PR TITLE
Add changelog and document release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Nothing yet.
+
+## [0.1.0] - 2024-05-09
+
+### Added
+- Initial release of the raid scoring utilities and scoreboard generator.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,14 @@ Thanks for your interest in improving PoGo Analyzer! This guide explains how to 
 - **Coding style** – follow the naming conventions documented in `docs/api.md`. Run `ruff check` and `black .` to verify formatting before submitting.
 - **Data updates** – when editing `pogo_analyzer/data/raid_entries.py`, make sure notes explain any special move requirements or mega considerations so readers understand the resulting score.
 
+## Release process
+
+1. Make sure the `CHANGELOG.md` "Unreleased" section accurately reflects the upcoming release. Move its entries into a new version section dated for the release.
+2. Bump the version number in `pyproject.toml`. The package exposes the `pogo_analyzer.__version__` attribute via this value, so no other files need manual edits.
+3. Run `ruff check`, `black . --check`, and `python -m unittest` to verify the codebase is clean and the tests pass.
+4. Commit the changes, create an annotated tag such as `git tag -a vX.Y.Z -m "Release vX.Y.Z"`, and push both the branch and tag.
+5. Build the distribution artifacts with `python -m build` and upload them using `twine upload dist/*` once you're ready to publish on PyPI.
+
 ## Pull requests
 
 1. Create a descriptive branch name (e.g., `feature/add-shadow-support`).

--- a/pogo_analyzer/__init__.py
+++ b/pogo_analyzer/__init__.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import re
+from importlib import metadata as _metadata
+from pathlib import Path
+
 from .data.raid_entries import (
     DEFAULT_RAID_ENTRIES,
     IVSpread,
@@ -11,6 +15,23 @@ from .data.raid_entries import (
 from .raid_entries import RAID_ENTRIES, build_rows
 from .scoring import calculate_iv_bonus, calculate_raid_score, iv_bonus, raid_score
 from .simple_table import Row, SimpleSeries, SimpleTable
+
+
+def _read_local_version() -> str:
+    """Return the project version from ``pyproject.toml`` when not installed."""
+
+    pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    if pyproject.is_file():
+        match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject.read_text(), re.MULTILINE)
+        if match:
+            return match.group(1)
+    return "0.0.0"
+
+
+try:
+    __version__ = _metadata.version("pogo-analyzer")
+except _metadata.PackageNotFoundError:
+    __version__ = _read_local_version()
 
 __all__ = [
     "DEFAULT_RAID_ENTRIES",
@@ -26,4 +47,5 @@ __all__ = [
     "calculate_raid_score",
     "iv_bonus",
     "raid_score",
+    "__version__",
 ]


### PR DESCRIPTION
## Summary
- add a Keep a Changelog formatted CHANGELOG file
- expose the package version via pogo_analyzer.__version__ with a local fallback
- document the release workflow in CONTRIBUTING.md

## Testing
- python -m unittest
- ruff check pogo_analyzer/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68c97e66b804832895ee9685351ee30e