### PR TITLE
Load raid entries from JSON dataset

### DIFF
--- a/pogo_analyzer/__init__.py
+++ b/pogo_analyzer/__init__.py
@@ -8,9 +8,11 @@ from pathlib import Path
 
 from .data.raid_entries import (
     DEFAULT_RAID_ENTRIES,
+    DEFAULT_RAID_ENTRY_METADATA,
     IVSpread,
     PokemonRaidEntry,
     build_entry_rows,
+    load_raid_entries,
 )
 from .raid_entries import RAID_ENTRIES, build_rows
 from .scoreboard import (
@@ -46,6 +48,7 @@ except _metadata.PackageNotFoundError:
 
 __all__ = [
     "DEFAULT_RAID_ENTRIES",
+    "DEFAULT_RAID_ENTRY_METADATA",
     "IVSpread",
     "PokemonRaidEntry",
     "RAID_ENTRIES",
@@ -53,6 +56,7 @@ __all__ = [
     "SimpleSeries",
     "SimpleTable",
     "build_entry_rows",
+    "load_raid_entries",
     "build_rows",
     "TableLike",
     "ScoreboardExportConfig",

--- a/pogo_analyzer/data/__init__.py
+++ b/pogo_analyzer/data/__init__.py
@@ -4,18 +4,22 @@ from __future__ import annotations
 
 from .raid_entries import (
     DEFAULT_RAID_ENTRIES,
+    DEFAULT_RAID_ENTRY_METADATA,
     RAID_ENTRIES,
     IVSpread,
     PokemonRaidEntry,
     build_entry_rows,
     build_rows,
+    load_raid_entries,
 )
 
 __all__ = [
     "DEFAULT_RAID_ENTRIES",
+    "DEFAULT_RAID_ENTRY_METADATA",
     "IVSpread",
     "PokemonRaidEntry",
     "RAID_ENTRIES",
     "build_entry_rows",
     "build_rows",
+    "load_raid_entries",
 ]

--- a/pogo_analyzer/data/raid_entries.json
+++ b/pogo_analyzer/data/raid_entries.json
@@ -1,0 +1,1078 @@
+{
+  "metadata": {
+    "schema_version": 1,
+    "description": "Curated Pokémon raid entries backing the default raid scoreboard. The metadata documents supported fields so additional columns can be added without breaking the loader.",
+    "fields": {
+      "name": {
+        "type": "string",
+        "required": true,
+        "description": "Display label for the Pokémon entry (may include annotations)."
+      },
+      "ivs": {
+        "type": "array[int,int,int]",
+        "required": true,
+        "description": "Attack, Defence, and Stamina IV values in that order."
+      },
+      "final_form": {
+        "type": "string",
+        "required": false,
+        "description": "Final evolution or mega form text shown in the report."
+      },
+      "role": {
+        "type": "string",
+        "required": false,
+        "description": "Short label describing the Pokémon's raid role."
+      },
+      "base": {
+        "type": "number",
+        "required": true,
+        "description": "Base raid score before IV/bonus adjustments (1-100)."
+      },
+      "lucky": {
+        "type": "boolean",
+        "required": false,
+        "description": "Whether the entry assumes the Lucky trade bonus."
+      },
+      "shadow": {
+        "type": "boolean",
+        "required": false,
+        "description": "Whether the Pokémon is treated as its Shadow variant."
+      },
+      "needs_tm": {
+        "type": "boolean",
+        "required": false,
+        "description": "Set when an Elite TM or event move is required."
+      },
+      "mega_now": {
+        "type": "boolean",
+        "required": false,
+        "description": "True when the Pokémon currently has an available mega form."
+      },
+      "mega_soon": {
+        "type": "boolean",
+        "required": false,
+        "description": "True when a mega form is expected soon and relevant to the entry."
+      },
+      "notes": {
+        "type": "string",
+        "required": false,
+        "description": "Free-form commentary explaining the score and context."
+      },
+      "purified": {
+        "type": "boolean",
+        "required": false,
+        "description": "Marks purified bonuses applied in the table output."
+      },
+      "best_buddy": {
+        "type": "boolean",
+        "required": false,
+        "description": "Marks best buddy bonuses applied in the table output."
+      }
+    },
+    "columns": {
+      "Your Pokémon": {
+        "description": "Formatted Pokémon name plus variant suffixes.",
+        "source": "PokemonRaidEntry.formatted_name"
+      },
+      "IV (Atk/Def/Sta)": {
+        "description": "String representation of the IV tuple.",
+        "source": "PokemonRaidEntry.iv_text"
+      },
+      "Final Raid Form": {
+        "description": "Final evolution or mega text displayed in the scoreboard.",
+        "source": "PokemonRaidEntry.final_form"
+      },
+      "Primary Role": {
+        "description": "Short role descriptor for quick scanning.",
+        "source": "PokemonRaidEntry.role"
+      },
+      "Move Needs (CD/ETM?)": {
+        "description": "Indicates whether a special move is required.",
+        "source": "PokemonRaidEntry.move_text"
+      },
+      "Mega Available": {
+        "description": "Highlights if a mega form is usable now or soon.",
+        "source": "PokemonRaidEntry.mega_text"
+      },
+      "Raid Score (1-100)": {
+        "description": "Calculated raid score including IV/lucky bonuses.",
+        "source": "PokemonRaidEntry.to_row"
+      },
+      "Why it scores like this": {
+        "description": "Explanatory notes shown to the player.",
+        "source": "PokemonRaidEntry.notes"
+      }
+    }
+  },
+  "entries": [
+    {
+      "name": "Snover",
+      "ivs": [
+        14,
+        12,
+        14
+      ],
+      "final_form": "Abomasnow / Mega Abomasnow",
+      "role": "Ice (mega support)",
+      "base": 80,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "Mega Abomasnow is a strong Ice/Grass team booster; regular Abomasnow is serviceable but not top DPS.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Riolu #1",
+      "ivs": [
+        14,
+        12,
+        13
+      ],
+      "final_form": "Lucario",
+      "role": "Fighting DPS",
+      "base": 89,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": true,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Lucario with Aura Sphere is top-tier Fighting; may require event/Elite TM for optimal moves.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Riolu #2",
+      "ivs": [
+        13,
+        15,
+        12
+      ],
+      "final_form": "Lucario",
+      "role": "Fighting DPS",
+      "base": 89,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": true,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Same as above — excellent attacker with the right moves.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Numel",
+      "ivs": [
+        15,
+        13,
+        11
+      ],
+      "final_form": "Camerupt / Mega Camerupt",
+      "role": "Fire/Ground (mega support)",
+      "base": 76,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": true,
+      "notes": "Regular Camerupt is weak; Mega Camerupt debut is imminent and mainly useful as a lobby booster.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Exeggutor",
+      "ivs": [
+        15,
+        13,
+        13
+      ],
+      "final_form": "Exeggutor",
+      "role": "Grass/Psychic (budget)",
+      "base": 70,
+      "lucky": true,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Outclassed by modern Grass/Psychic attackers; Lucky makes it cheap if you need filler.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Lopunny",
+      "ivs": [
+        15,
+        13,
+        14
+      ],
+      "final_form": "Mega Lopunny",
+      "role": "Fighting mega support",
+      "base": 78,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "Personal DPS is middling, but Mega boosts Fighting/Normal teams.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Starly",
+      "ivs": [
+        14,
+        12,
+        15
+      ],
+      "final_form": "Staraptor (Gust)",
+      "role": "Flying DPS (budget)",
+      "base": 77,
+      "lucky": true,
+      "shadow": false,
+      "needs_tm": true,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Gust is CD-only; with Gust it's a solid budget flier.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Flabebe (lucky)",
+      "ivs": [
+        14,
+        13,
+        15
+      ],
+      "final_form": "Florges",
+      "role": "Fairy (low DPS)",
+      "base": 58,
+      "lucky": true,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Florges has low raid DPS; mainly collection/PvP.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Flabebe #2",
+      "ivs": [
+        15,
+        11,
+        11
+      ],
+      "final_form": "Florges",
+      "role": "Fairy (low DPS)",
+      "base": 58,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Same as above.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Flabebe #3",
+      "ivs": [
+        15,
+        13,
+        15
+      ],
+      "final_form": "Florges",
+      "role": "Fairy (low DPS)",
+      "base": 58,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Same as above.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Flabebe #4",
+      "ivs": [
+        15,
+        13,
+        15
+      ],
+      "final_form": "Florges",
+      "role": "Fairy (low DPS)",
+      "base": 58,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Same as above.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Litten",
+      "ivs": [
+        15,
+        10,
+        15
+      ],
+      "final_form": "Incineroar (Blast Burn)",
+      "role": "Fire DPS (mid)",
+      "base": 78,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": true,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "CD move Blast Burn needed; still behind top Fire like Reshiram/Blaziken/Chandelure.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Heracross #1",
+      "ivs": [
+        13,
+        11,
+        5
+      ],
+      "final_form": "Mega Heracross",
+      "role": "Bug/Fighting (mega & DPS)",
+      "base": 90,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "Mega Heracross is one of the strongest Bug attackers and solid Fighting mega.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Heracross #2",
+      "ivs": [
+        14,
+        0,
+        10
+      ],
+      "final_form": "Mega Heracross",
+      "role": "Bug/Fighting (mega & DPS)",
+      "base": 90,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "Mega Heracross is one of the strongest Bug attackers and solid Fighting mega.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Heracross #3",
+      "ivs": [
+        10,
+        9,
+        5
+      ],
+      "final_form": "Mega Heracross",
+      "role": "Bug/Fighting (mega & DPS)",
+      "base": 90,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "Mega Heracross is one of the strongest Bug attackers and solid Fighting mega.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Heracross #4",
+      "ivs": [
+        12,
+        8,
+        11
+      ],
+      "final_form": "Mega Heracross",
+      "role": "Bug/Fighting (mega & DPS)",
+      "base": 90,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "Mega Heracross is one of the strongest Bug attackers and solid Fighting mega.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Heracross #5",
+      "ivs": [
+        13,
+        8,
+        14
+      ],
+      "final_form": "Mega Heracross",
+      "role": "Bug/Fighting (mega & DPS)",
+      "base": 90,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "Mega Heracross is one of the strongest Bug attackers and solid Fighting mega.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Shadow Tyrunt",
+      "ivs": [
+        14,
+        15,
+        5
+      ],
+      "final_form": "Shadow Tyrantrum",
+      "role": "Rock/Dragon DPS (niche)",
+      "base": 80,
+      "lucky": false,
+      "shadow": true,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Fun and strong on paper, but still behind top Rock/Dragon specialists in most raids.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Beldum",
+      "ivs": [
+        15,
+        9,
+        4
+      ],
+      "final_form": "Metagross (Meteor Mash)",
+      "role": "Steel DPS (top)",
+      "base": 90,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": true,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Meteor Mash is mandatory; top Steel attacker when built.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Electabuzz",
+      "ivs": [
+        15,
+        10,
+        3
+      ],
+      "final_form": "Electivire",
+      "role": "Electric DPS (good)",
+      "base": 82,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Strong budget Electric; behind Legendaries and Shadows but still very usable.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Gurdurr",
+      "ivs": [
+        12,
+        6,
+        14
+      ],
+      "final_form": "Conkeldurr",
+      "role": "Fighting DPS (top non-mega)",
+      "base": 86,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Conkeldurr is a top non-mega Fighting attacker.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Crawdaunt",
+      "ivs": [
+        15,
+        13,
+        15
+      ],
+      "final_form": "Crawdaunt",
+      "role": "Water/Dark (spice)",
+      "base": 60,
+      "lucky": true,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Glass cannon, outclassed by most Water/Dark specialists.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Shadow Magnemite",
+      "ivs": [
+        11,
+        6,
+        10
+      ],
+      "final_form": "Shadow Magnezone",
+      "role": "Electric DPS (top non-legend)",
+      "base": 88,
+      "lucky": false,
+      "shadow": true,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Shadow Magnezone is among the best non-legend Electric attackers.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Shadow Gastly",
+      "ivs": [
+        9,
+        11,
+        15
+      ],
+      "final_form": "Shadow Gengar",
+      "role": "Ghost DPS (apex glass cannon)",
+      "base": 93,
+      "lucky": false,
+      "shadow": true,
+      "needs_tm": true,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Shadow Gengar has elite DPS; benefits from legacy Lick/Shadow Ball.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Treecko",
+      "ivs": [
+        14,
+        13,
+        10
+      ],
+      "final_form": "Sceptile (Frenzy Plant) / Mega Sceptile",
+      "role": "Grass DPS (top w/ Mega)",
+      "base": 88,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": true,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "Frenzy Plant Sceptile is excellent; Mega Sceptile is the best Grass mega.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Arcanine",
+      "ivs": [
+        15,
+        12,
+        10
+      ],
+      "final_form": "Arcanine",
+      "role": "Fire DPS (mid)",
+      "base": 72,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Usable but far behind top Fire options.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Shadow Kirlia",
+      "ivs": [
+        11,
+        11,
+        11
+      ],
+      "final_form": "Shadow Gardevoir",
+      "role": "Fairy DPS (top non-mega)",
+      "base": 88,
+      "lucky": false,
+      "shadow": true,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Shadow Gardevoir is a top non-mega Fairy attacker; consider Gardevoir over Gallade for raids.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Drilbur",
+      "ivs": [
+        14,
+        15,
+        14
+      ],
+      "final_form": "Excadrill",
+      "role": "Ground DPS (top non-legend)",
+      "base": 86,
+      "lucky": true,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Excadrill has great DPS and resistances; lucky makes it cheap.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Grovyle",
+      "ivs": [
+        15,
+        12,
+        13
+      ],
+      "final_form": "Sceptile (Frenzy Plant) / Mega Sceptile",
+      "role": "Grass DPS",
+      "base": 88,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": true,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "Same as Treecko — pick your better IV to evolve.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Alakazam",
+      "ivs": [
+        14,
+        13,
+        15
+      ],
+      "final_form": "Alakazam / Mega Alakazam",
+      "role": "Psychic DPS",
+      "base": 80,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "As a non-mega it's okay; Mega Alakazam is a strong Psychic mega booster.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Drowzee",
+      "ivs": [
+        14,
+        15,
+        13
+      ],
+      "final_form": "Hypno",
+      "role": "Psychic (low DPS)",
+      "base": 55,
+      "lucky": true,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Not raid-relevant; mostly PvP/collection.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Scyther",
+      "ivs": [
+        12,
+        15,
+        14
+      ],
+      "final_form": "Scizor / Mega Scizor",
+      "role": "Bug/Steel (mega support)",
+      "base": 82,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "Scizor is mid for raids; Mega Scizor is a handy Bug/Steel booster.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Hariyama",
+      "ivs": [
+        14,
+        15,
+        12
+      ],
+      "final_form": "Hariyama",
+      "role": "Fighting DPS (budget)",
+      "base": 80,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Solid budget Fighter; outclassed by Machamp/Conkeldurr/Lucario.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Blastoise",
+      "ivs": [
+        15,
+        14,
+        14
+      ],
+      "final_form": "Blastoise / Mega Blastoise",
+      "role": "Water (mega support)",
+      "base": 82,
+      "lucky": true,
+      "shadow": false,
+      "needs_tm": true,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "Hydro Cannon needed for non-mega; Mega Blastoise is a strong Water mega.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Machamp",
+      "ivs": [
+        15,
+        13,
+        14
+      ],
+      "final_form": "Machamp",
+      "role": "Fighting DPS (top non-shadow)",
+      "base": 84,
+      "lucky": true,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Still a top non-legend Fighter with Counter/Dynamic Punch.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Shadow Drilbur",
+      "ivs": [
+        14,
+        4,
+        15
+      ],
+      "final_form": "Shadow Excadrill",
+      "role": "Ground DPS (apex)",
+      "base": 92,
+      "lucky": false,
+      "shadow": true,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Shadow Excadrill is among the best Ground DPS options; frailer but hits very hard.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Gengar (lucky)",
+      "ivs": [
+        15,
+        13,
+        12
+      ],
+      "final_form": "Gengar / Mega Gengar",
+      "role": "Ghost DPS (high)",
+      "base": 82,
+      "lucky": true,
+      "shadow": false,
+      "needs_tm": true,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "Great non-shadow DPS; can Mega for top-tier boosts.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Gengar (hundo)",
+      "ivs": [
+        15,
+        15,
+        15
+      ],
+      "final_form": "Gengar / Mega Gengar",
+      "role": "Ghost DPS (high)",
+      "base": 85,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": true,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "Perfect IVs; outstanding Mega candidate.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Venusaur",
+      "ivs": [
+        15,
+        14,
+        15
+      ],
+      "final_form": "Venusaur / Mega Venusaur",
+      "role": "Grass DPS (good)",
+      "base": 83,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": true,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "Frenzy Plant Venusaur is solid; Mega Venusaur offers bulky Grass mega support.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Rhyhorn",
+      "ivs": [
+        13,
+        13,
+        15
+      ],
+      "final_form": "Rhyperior (Rock Wrecker)",
+      "role": "Rock DPS (top TDO)",
+      "base": 88,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": true,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Rock Wrecker is mandatory; elite TDO and flexible Ground coverage.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Gyarados",
+      "ivs": [
+        14,
+        13,
+        15
+      ],
+      "final_form": "Gyarados / Mega Gyarados",
+      "role": "Water/Dark (mega support)",
+      "base": 82,
+      "lucky": true,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "As a mega it's a great Dark/Water booster; non-mega is decent but outclassed.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Larvitar #1",
+      "ivs": [
+        15,
+        12,
+        13
+      ],
+      "final_form": "Tyranitar (Brutal Swing) / Mega Tyranitar",
+      "role": "Dark/Rock DPS",
+      "base": 86,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": true,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "Brutal Swing makes Dark TTar great; Smack Down needs ETM for Rock role; Mega Tyranitar is elite.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Larvitar #2",
+      "ivs": [
+        15,
+        15,
+        10
+      ],
+      "final_form": "Tyranitar (Brutal Swing) / Mega Tyranitar",
+      "role": "Dark/Rock DPS",
+      "base": 86,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": true,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "Slightly better bulk; same notes as above.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Shadow Machoke",
+      "ivs": [
+        13,
+        12,
+        7
+      ],
+      "final_form": "Shadow Machamp",
+      "role": "Fighting DPS (apex non-mega)",
+      "base": 90,
+      "lucky": false,
+      "shadow": true,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Shadow Machamp is one of the best Fighters; very high DPS.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Haunter",
+      "ivs": [
+        14,
+        14,
+        15
+      ],
+      "final_form": "Gengar / Mega Gengar",
+      "role": "Ghost DPS (high)",
+      "base": 84,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": true,
+      "mega_now": true,
+      "mega_soon": false,
+      "notes": "Great IVs; evolve for another strong Gengar or Mega candidate.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Shadow Cyndaquil",
+      "ivs": [
+        13,
+        0,
+        12
+      ],
+      "final_form": "Shadow Typhlosion (Blast Burn)",
+      "role": "Fire DPS (high)",
+      "base": 87,
+      "lucky": false,
+      "shadow": true,
+      "needs_tm": true,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "With Blast Burn it's a strong Fire attacker; very glassy as a Shadow.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Throh",
+      "ivs": [
+        15,
+        6,
+        5
+      ],
+      "final_form": "Throh",
+      "role": "Fighting (very low DPS)",
+      "base": 52,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "No raid relevance; belongs in PvP/collection, not raids.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Moltres",
+      "ivs": [
+        11,
+        13,
+        14
+      ],
+      "final_form": "Moltres",
+      "role": "Fire/Flying DPS (legend)",
+      "base": 85,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Strong Fire or Flying attacker; still relevant in many raids.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Shadow Giratina",
+      "ivs": [
+        11,
+        9,
+        14
+      ],
+      "final_form": "Shadow Giratina (Origin preferred)",
+      "role": "Ghost/Dragon DPS (apex)",
+      "base": 95,
+      "lucky": false,
+      "shadow": true,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Shadow Giratina debuted recently; Origin Forme is an elite Ghost raider.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Shadow Roggenrola",
+      "ivs": [
+        10,
+        12,
+        5
+      ],
+      "final_form": "Shadow Gigalith (Meteor Beam)",
+      "role": "Rock DPS (strong)",
+      "base": 83,
+      "lucky": false,
+      "shadow": true,
+      "needs_tm": true,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Meteor Beam is key; shadow gives it serious punch.",
+      "purified": false,
+      "best_buddy": false
+    },
+    {
+      "name": "Excadrill (Dynamax)",
+      "ivs": [
+        14,
+        14,
+        10
+      ],
+      "final_form": "Excadrill",
+      "role": "Ground DPS (top non-legend)",
+      "base": 86,
+      "lucky": false,
+      "shadow": false,
+      "needs_tm": false,
+      "mega_now": false,
+      "mega_soon": false,
+      "notes": "Dynamax tag doesn't change its standard raid role; very good Ground attacker.",
+      "purified": false,
+      "best_buddy": false
+    }
+  ]
+}

--- a/pogo_analyzer/data/raid_entries.py
+++ b/pogo_analyzer/data/raid_entries.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from functools import cache
+from importlib import resources
+from pathlib import Path
+from typing import Any, Iterable, Mapping
 
 from pogo_analyzer.scoring import calculate_iv_bonus, calculate_raid_score
 from pogo_analyzer.scoring.metrics import SCORE_MAX, SCORE_MIN
@@ -131,6 +135,19 @@ class PokemonRaidEntry:
         return self.to_row()
 
 
+_ENTRY_FIELD_NAMES = {field.name for field in fields(PokemonRaidEntry)}
+_STRING_FIELDS = {"name", "final_form", "role", "notes"}
+_BOOLEAN_FIELDS = {
+    "lucky",
+    "shadow",
+    "needs_tm",
+    "mega_now",
+    "mega_soon",
+    "purified",
+    "best_buddy",
+}
+
+
 @cache
 def _entry_row_items(entry: PokemonRaidEntry) -> tuple[tuple[str, object], ...]:
     """Return a cached tuple of row items for a raid entry."""
@@ -151,457 +168,174 @@ def build_rows(entries: Sequence[PokemonRaidEntry]) -> list[Row]:
     return build_entry_rows(entries)
 
 
-DEFAULT_RAID_ENTRIES: list[PokemonRaidEntry] = [
-    PokemonRaidEntry(
-        "Snover",
-        (14, 12, 14),
-        final_form="Abomasnow / Mega Abomasnow",
-        role="Ice (mega support)",
-        base=80,
-        mega_now=True,
-        notes="Mega Abomasnow is a strong Ice/Grass team booster; regular Abomasnow is serviceable but not top DPS.",
-    ),
-    PokemonRaidEntry(
-        "Riolu #1",
-        (14, 12, 13),
-        final_form="Lucario",
-        role="Fighting DPS",
-        base=89,
-        needs_tm=True,
-        notes="Lucario with Aura Sphere is top-tier Fighting; may require event/Elite TM for optimal moves.",
-    ),
-    PokemonRaidEntry(
-        "Riolu #2",
-        (13, 15, 12),
-        final_form="Lucario",
-        role="Fighting DPS",
-        base=89,
-        needs_tm=True,
-        notes="Same as above — excellent attacker with the right moves.",
-    ),
-    PokemonRaidEntry(
-        "Numel",
-        (15, 13, 11),
-        final_form="Camerupt / Mega Camerupt",
-        role="Fire/Ground (mega support)",
-        base=76,
-        mega_soon=True,
-        notes="Regular Camerupt is weak; Mega Camerupt debut is imminent and mainly useful as a lobby booster.",
-    ),
-    PokemonRaidEntry(
-        "Exeggutor",
-        (15, 13, 13),
-        final_form="Exeggutor",
-        role="Grass/Psychic (budget)",
-        base=70,
-        lucky=True,
-        notes="Outclassed by modern Grass/Psychic attackers; Lucky makes it cheap if you need filler.",
-    ),
-    PokemonRaidEntry(
-        "Lopunny",
-        (15, 13, 14),
-        final_form="Mega Lopunny",
-        role="Fighting mega support",
-        base=78,
-        mega_now=True,
-        notes="Personal DPS is middling, but Mega boosts Fighting/Normal teams.",
-    ),
-    PokemonRaidEntry(
-        "Starly",
-        (14, 12, 15),
-        final_form="Staraptor (Gust)",
-        role="Flying DPS (budget)",
-        base=77,
-        lucky=True,
-        needs_tm=True,
-        notes="Gust is CD-only; with Gust it's a solid budget flier.",
-    ),
-    PokemonRaidEntry(
-        "Flabebe (lucky)",
-        (14, 13, 15),
-        final_form="Florges",
-        role="Fairy (low DPS)",
-        base=58,
-        lucky=True,
-        notes="Florges has low raid DPS; mainly collection/PvP.",
-    ),
-    PokemonRaidEntry(
-        "Flabebe #2",
-        (15, 11, 11),
-        final_form="Florges",
-        role="Fairy (low DPS)",
-        base=58,
-        notes="Same as above.",
-    ),
-    PokemonRaidEntry(
-        "Flabebe #3",
-        (15, 13, 15),
-        final_form="Florges",
-        role="Fairy (low DPS)",
-        base=58,
-        notes="Same as above.",
-    ),
-    PokemonRaidEntry(
-        "Flabebe #4",
-        (15, 13, 15),
-        final_form="Florges",
-        role="Fairy (low DPS)",
-        base=58,
-        notes="Same as above.",
-    ),
-    PokemonRaidEntry(
-        "Litten",
-        (15, 10, 15),
-        final_form="Incineroar (Blast Burn)",
-        role="Fire DPS (mid)",
-        base=78,
-        needs_tm=True,
-        notes="CD move Blast Burn needed; still behind top Fire like Reshiram/Blaziken/Chandelure.",
-    ),
-]
 
-# Additional entries appended below to keep file manageable when editing blocks.
-DEFAULT_RAID_ENTRIES += [
-    PokemonRaidEntry(
-        f"Heracross #{index}",
-        ivs,
-        final_form="Mega Heracross",
-        role="Bug/Fighting (mega & DPS)",
-        base=90,
-        mega_now=True,
-        notes="Mega Heracross is one of the strongest Bug attackers and solid Fighting mega.",
-    )
-    for index, ivs in enumerate(
-        [(13, 11, 5), (14, 0, 10), (10, 9, 5), (12, 8, 11), (13, 8, 14)],
-        1,
-    )
-]
+def _read_payload(path: Path | str | None) -> tuple[Mapping[str, Any], list[Any]]:
+    """Return metadata and entry data loaded from JSON."""
 
-DEFAULT_RAID_ENTRIES += [
-    PokemonRaidEntry(
-        "Shadow Tyrunt",
-        (14, 15, 5),
-        final_form="Shadow Tyrantrum",
-        role="Rock/Dragon DPS (niche)",
-        base=80,
-        shadow=True,
-        notes="Fun and strong on paper, but still behind top Rock/Dragon specialists in most raids.",
-    ),
-    PokemonRaidEntry(
-        "Beldum",
-        (15, 9, 4),
-        final_form="Metagross (Meteor Mash)",
-        role="Steel DPS (top)",
-        base=90,
-        needs_tm=True,
-        notes="Meteor Mash is mandatory; top Steel attacker when built.",
-    ),
-    PokemonRaidEntry(
-        "Electabuzz",
-        (15, 10, 3),
-        final_form="Electivire",
-        role="Electric DPS (good)",
-        base=82,
-        notes="Strong budget Electric; behind Legendaries and Shadows but still very usable.",
-    ),
-    PokemonRaidEntry(
-        "Gurdurr",
-        (12, 6, 14),
-        final_form="Conkeldurr",
-        role="Fighting DPS (top non-mega)",
-        base=86,
-        notes="Conkeldurr is a top non-mega Fighting attacker.",
-    ),
-    PokemonRaidEntry(
-        "Crawdaunt",
-        (15, 13, 15),
-        final_form="Crawdaunt",
-        role="Water/Dark (spice)",
-        base=60,
-        lucky=True,
-        notes="Glass cannon, outclassed by most Water/Dark specialists.",
-    ),
-    PokemonRaidEntry(
-        "Shadow Magnemite",
-        (11, 6, 10),
-        final_form="Shadow Magnezone",
-        role="Electric DPS (top non-legend)",
-        base=88,
-        shadow=True,
-        notes="Shadow Magnezone is among the best non-legend Electric attackers.",
-    ),
-    PokemonRaidEntry(
-        "Shadow Gastly",
-        (9, 11, 15),
-        final_form="Shadow Gengar",
-        role="Ghost DPS (apex glass cannon)",
-        base=93,
-        shadow=True,
-        needs_tm=True,
-        notes="Shadow Gengar has elite DPS; benefits from legacy Lick/Shadow Ball.",
-    ),
-    PokemonRaidEntry(
-        "Treecko",
-        (14, 13, 10),
-        final_form="Sceptile (Frenzy Plant) / Mega Sceptile",
-        role="Grass DPS (top w/ Mega)",
-        base=88,
-        needs_tm=True,
-        mega_now=True,
-        notes="Frenzy Plant Sceptile is excellent; Mega Sceptile is the best Grass mega.",
-    ),
-    PokemonRaidEntry(
-        "Arcanine",
-        (15, 12, 10),
-        final_form="Arcanine",
-        role="Fire DPS (mid)",
-        base=72,
-        notes="Usable but far behind top Fire options.",
-    ),
-    PokemonRaidEntry(
-        "Shadow Kirlia",
-        (11, 11, 11),
-        final_form="Shadow Gardevoir",
-        role="Fairy DPS (top non-mega)",
-        base=88,
-        shadow=True,
-        notes="Shadow Gardevoir is a top non-mega Fairy attacker; consider Gardevoir over Gallade for raids.",
-    ),
-    PokemonRaidEntry(
-        "Drilbur",
-        (14, 15, 14),
-        final_form="Excadrill",
-        role="Ground DPS (top non-legend)",
-        base=86,
-        lucky=True,
-        notes="Excadrill has great DPS and resistances; lucky makes it cheap.",
-    ),
-    PokemonRaidEntry(
-        "Grovyle",
-        (15, 12, 13),
-        final_form="Sceptile (Frenzy Plant) / Mega Sceptile",
-        role="Grass DPS",
-        base=88,
-        needs_tm=True,
-        mega_now=True,
-        notes="Same as Treecko — pick your better IV to evolve.",
-    ),
-    PokemonRaidEntry(
-        "Alakazam",
-        (14, 13, 15),
-        final_form="Alakazam / Mega Alakazam",
-        role="Psychic DPS",
-        base=80,
-        mega_now=True,
-        notes="As a non-mega it's okay; Mega Alakazam is a strong Psychic mega booster.",
-    ),
-    PokemonRaidEntry(
-        "Drowzee",
-        (14, 15, 13),
-        final_form="Hypno",
-        role="Psychic (low DPS)",
-        base=55,
-        lucky=True,
-        notes="Not raid-relevant; mostly PvP/collection.",
-    ),
-    PokemonRaidEntry(
-        "Scyther",
-        (12, 15, 14),
-        final_form="Scizor / Mega Scizor",
-        role="Bug/Steel (mega support)",
-        base=82,
-        mega_now=True,
-        notes="Scizor is mid for raids; Mega Scizor is a handy Bug/Steel booster.",
-    ),
-    PokemonRaidEntry(
-        "Hariyama",
-        (14, 15, 12),
-        final_form="Hariyama",
-        role="Fighting DPS (budget)",
-        base=80,
-        notes="Solid budget Fighter; outclassed by Machamp/Conkeldurr/Lucario.",
-    ),
-    PokemonRaidEntry(
-        "Blastoise",
-        (15, 14, 14),
-        final_form="Blastoise / Mega Blastoise",
-        role="Water (mega support)",
-        base=82,
-        lucky=True,
-        needs_tm=True,
-        mega_now=True,
-        notes="Hydro Cannon needed for non-mega; Mega Blastoise is a strong Water mega.",
-    ),
-    PokemonRaidEntry(
-        "Machamp",
-        (15, 13, 14),
-        final_form="Machamp",
-        role="Fighting DPS (top non-shadow)",
-        base=84,
-        lucky=True,
-        notes="Still a top non-legend Fighter with Counter/Dynamic Punch.",
-    ),
-    PokemonRaidEntry(
-        "Shadow Drilbur",
-        (14, 4, 15),
-        final_form="Shadow Excadrill",
-        role="Ground DPS (apex)",
-        base=92,
-        shadow=True,
-        notes="Shadow Excadrill is among the best Ground DPS options; frailer but hits very hard.",
-    ),
-    PokemonRaidEntry(
-        "Gengar (lucky)",
-        (15, 13, 12),
-        final_form="Gengar / Mega Gengar",
-        role="Ghost DPS (high)",
-        base=82,
-        lucky=True,
-        needs_tm=True,
-        mega_now=True,
-        notes="Great non-shadow DPS; can Mega for top-tier boosts.",
-    ),
-    PokemonRaidEntry(
-        "Gengar (hundo)",
-        (15, 15, 15),
-        final_form="Gengar / Mega Gengar",
-        role="Ghost DPS (high)",
-        base=85,
-        needs_tm=True,
-        mega_now=True,
-        notes="Perfect IVs; outstanding Mega candidate.",
-    ),
-    PokemonRaidEntry(
-        "Venusaur",
-        (15, 14, 15),
-        final_form="Venusaur / Mega Venusaur",
-        role="Grass DPS (good)",
-        base=83,
-        needs_tm=True,
-        mega_now=True,
-        notes="Frenzy Plant Venusaur is solid; Mega Venusaur offers bulky Grass mega support.",
-    ),
-    PokemonRaidEntry(
-        "Rhyhorn",
-        (13, 13, 15),
-        final_form="Rhyperior (Rock Wrecker)",
-        role="Rock DPS (top TDO)",
-        base=88,
-        needs_tm=True,
-        notes="Rock Wrecker is mandatory; elite TDO and flexible Ground coverage.",
-    ),
-    PokemonRaidEntry(
-        "Gyarados",
-        (14, 13, 15),
-        final_form="Gyarados / Mega Gyarados",
-        role="Water/Dark (mega support)",
-        base=82,
-        lucky=True,
-        mega_now=True,
-        notes="As a mega it's a great Dark/Water booster; non-mega is decent but outclassed.",
-    ),
-    PokemonRaidEntry(
-        "Larvitar #1",
-        (15, 12, 13),
-        final_form="Tyranitar (Brutal Swing) / Mega Tyranitar",
-        role="Dark/Rock DPS",
-        base=86,
-        needs_tm=True,
-        mega_now=True,
-        notes="Brutal Swing makes Dark TTar great; Smack Down needs ETM for Rock role; Mega Tyranitar is elite.",
-    ),
-    PokemonRaidEntry(
-        "Larvitar #2",
-        (15, 15, 10),
-        final_form="Tyranitar (Brutal Swing) / Mega Tyranitar",
-        role="Dark/Rock DPS",
-        base=86,
-        needs_tm=True,
-        mega_now=True,
-        notes="Slightly better bulk; same notes as above.",
-    ),
-    PokemonRaidEntry(
-        "Shadow Machoke",
-        (13, 12, 7),
-        final_form="Shadow Machamp",
-        role="Fighting DPS (apex non-mega)",
-        base=90,
-        shadow=True,
-        notes="Shadow Machamp is one of the best Fighters; very high DPS.",
-    ),
-    PokemonRaidEntry(
-        "Haunter",
-        (14, 14, 15),
-        final_form="Gengar / Mega Gengar",
-        role="Ghost DPS (high)",
-        base=84,
-        needs_tm=True,
-        mega_now=True,
-        notes="Great IVs; evolve for another strong Gengar or Mega candidate.",
-    ),
-    PokemonRaidEntry(
-        "Shadow Cyndaquil",
-        (13, 0, 12),
-        final_form="Shadow Typhlosion (Blast Burn)",
-        role="Fire DPS (high)",
-        base=87,
-        shadow=True,
-        needs_tm=True,
-        notes="With Blast Burn it's a strong Fire attacker; very glassy as a Shadow.",
-    ),
-    PokemonRaidEntry(
-        "Throh",
-        (15, 6, 5),
-        final_form="Throh",
-        role="Fighting (very low DPS)",
-        base=52,
-        notes="No raid relevance; belongs in PvP/collection, not raids.",
-    ),
-    PokemonRaidEntry(
-        "Moltres",
-        (11, 13, 14),
-        final_form="Moltres",
-        role="Fire/Flying DPS (legend)",
-        base=85,
-        notes="Strong Fire or Flying attacker; still relevant in many raids.",
-    ),
-    PokemonRaidEntry(
-        "Shadow Giratina",
-        (11, 9, 14),
-        final_form="Shadow Giratina (Origin preferred)",
-        role="Ghost/Dragon DPS (apex)",
-        base=95,
-        shadow=True,
-        notes="Shadow Giratina debuted recently; Origin Forme is an elite Ghost raider.",
-    ),
-    PokemonRaidEntry(
-        "Shadow Roggenrola",
-        (10, 12, 5),
-        final_form="Shadow Gigalith (Meteor Beam)",
-        role="Rock DPS (strong)",
-        base=83,
-        shadow=True,
-        needs_tm=True,
-        notes="Meteor Beam is key; shadow gives it serious punch.",
-    ),
-    PokemonRaidEntry(
-        "Excadrill (Dynamax)",
-        (14, 14, 10),
-        final_form="Excadrill",
-        role="Ground DPS (top non-legend)",
-        base=86,
-        notes="Dynamax tag doesn't change its standard raid role; very good Ground attacker.",
-    ),
-]
+    if path is None:
+        resource = resources.files(__package__).joinpath("raid_entries.json")
+        raw = resource.read_text(encoding="utf-8")
+    else:
+        raw = Path(path).read_text(encoding="utf-8")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:  # pragma: no cover - rarely triggered in tests.
+        raise ValueError(f"Failed to parse raid entry JSON: {exc}") from exc
+    if not isinstance(payload, Mapping):
+        raise ValueError("Raid entry data must be a JSON object.")
+    metadata = payload.get("metadata")
+    if not isinstance(metadata, Mapping):
+        raise ValueError("Raid entry payload requires a 'metadata' object.")
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("Raid entry payload requires an 'entries' array.")
+    return metadata, entries
 
+
+def _parse_metadata(metadata: Mapping[str, Any]) -> set[str]:
+    """Validate metadata and return the set of required field names."""
+
+    schema_version = metadata.get("schema_version")
+    if not isinstance(schema_version, int):
+        raise ValueError("Raid entry metadata must include an integer 'schema_version'.")
+    fields_metadata = metadata.get("fields")
+    if not isinstance(fields_metadata, Mapping):
+        raise ValueError("Raid entry metadata must include a 'fields' mapping.")
+    metadata_fields = set(fields_metadata)
+    missing = _ENTRY_FIELD_NAMES - metadata_fields
+    if missing:
+        missing_list = ", ".join(sorted(missing))
+        raise ValueError(
+            f"Raid entry metadata is missing definitions for fields: {missing_list}."
+        )
+    unsupported = metadata_fields - _ENTRY_FIELD_NAMES
+    if unsupported:
+        unsupported_list = ", ".join(sorted(unsupported))
+        raise ValueError(
+            "Raid entry metadata declares unsupported fields: "
+            f"{unsupported_list}."
+        )
+    required_fields: set[str] = set()
+    for field_name, descriptor in fields_metadata.items():
+        if not isinstance(descriptor, Mapping):
+            raise ValueError(
+                f"Raid entry metadata for field '{field_name}' must be an object."
+            )
+        required_flag = descriptor.get("required", False)
+        if not isinstance(required_flag, bool):
+            raise ValueError(
+                "Raid entry metadata for field '"
+                f"{field_name}' has non-boolean 'required'."
+            )
+        if required_flag:
+            required_fields.add(field_name)
+    columns = metadata.get("columns")
+    if columns is not None and not isinstance(columns, Mapping):
+        raise ValueError("Raid entry metadata 'columns' must be an object when provided.")
+    return required_fields
+
+
+def _coerce_entry(
+    raw_entry: Mapping[str, Any],
+    index: int,
+    required_fields: Iterable[str],
+) -> PokemonRaidEntry:
+    """Convert a JSON mapping into a :class:`PokemonRaidEntry`."""
+
+    entry_name = raw_entry.get("name", f"#{index}")
+    missing = [field for field in required_fields if field not in raw_entry]
+    if missing:
+        missing_list = ", ".join(sorted(missing))
+        raise ValueError(
+            f"Raid entry '{entry_name}' is missing required field(s): {missing_list}."
+        )
+    unknown = set(raw_entry) - _ENTRY_FIELD_NAMES
+    if unknown:
+        unknown_list = ", ".join(sorted(unknown))
+        raise ValueError(
+            f"Raid entry '{entry_name}' contains unknown field(s): {unknown_list}."
+        )
+    kwargs: dict[str, Any] = {}
+    for field_name in _ENTRY_FIELD_NAMES:
+        if field_name not in raw_entry:
+            continue
+        value = raw_entry[field_name]
+        if field_name == "ivs":
+            if not isinstance(value, (list, tuple)):
+                raise TypeError(
+                    f"Raid entry '{entry_name}' field 'ivs' must be a list of integers."
+                )
+            if len(value) != 3:
+                raise ValueError(
+                    f"Raid entry '{entry_name}' field 'ivs' must contain exactly three values."
+                )
+            if not all(isinstance(iv, int) and not isinstance(iv, bool) for iv in value):
+                raise TypeError(
+                    f"Raid entry '{entry_name}' field 'ivs' must contain integer values."
+                )
+            iv_tuple: IVSpread = (value[0], value[1], value[2])
+            kwargs[field_name] = iv_tuple
+        elif field_name == "base":
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(
+                    f"Raid entry '{entry_name}' field 'base' must be a number."
+                )
+            kwargs[field_name] = float(value)
+        elif field_name in _STRING_FIELDS:
+            if not isinstance(value, str):
+                raise TypeError(
+                    f"Raid entry '{entry_name}' field '{field_name}' must be a string."
+                )
+            kwargs[field_name] = value
+        elif field_name in _BOOLEAN_FIELDS:
+            if not isinstance(value, bool):
+                raise TypeError(
+                    f"Raid entry '{entry_name}' field '{field_name}' must be a boolean."
+                )
+            kwargs[field_name] = value
+        else:
+            kwargs[field_name] = value
+    try:
+        return PokemonRaidEntry(**kwargs)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Raid entry '{entry_name}' is invalid: {exc}") from exc
+
+
+def _load_entries_with_metadata(
+    path: Path | str | None = None,
+) -> tuple[list[PokemonRaidEntry], Mapping[str, Any]]:
+    """Load entries (and metadata) from the packaged JSON file or a custom path."""
+
+    metadata, raw_entries = _read_payload(path)
+    required_fields = _parse_metadata(metadata)
+    entries: list[PokemonRaidEntry] = []
+    for index, item in enumerate(raw_entries):
+        if not isinstance(item, Mapping):
+            raise ValueError(
+                f"Raid entry at index {index} must be an object; received {type(item).__name__}."
+            )
+        entries.append(_coerce_entry(item, index, required_fields))
+    return entries, metadata
+
+
+def load_raid_entries(path: Path | str | None = None) -> list[PokemonRaidEntry]:
+    """Return raid entries parsed from ``path`` or the bundled dataset."""
+
+    entries, _ = _load_entries_with_metadata(path)
+    return entries
+
+
+DEFAULT_RAID_ENTRIES, DEFAULT_RAID_ENTRY_METADATA = _load_entries_with_metadata()
 
 RAID_ENTRIES = DEFAULT_RAID_ENTRIES
 
 __all__ = [
     "DEFAULT_RAID_ENTRIES",
+    "DEFAULT_RAID_ENTRY_METADATA",
     "IVSpread",
     "PokemonRaidEntry",
     "RAID_ENTRIES",
     "build_entry_rows",
     "build_rows",
+    "load_raid_entries",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ py-modules = [
 [tool.setuptools.packages.find]
 include = ["pogo_analyzer*"]
 
+[tool.setuptools.package-data]
+"pogo_analyzer.data" = ["*.json"]
+
 [tool.black]
 line-length = 88
 target-version = ["py39"]


### PR DESCRIPTION
## Summary
- store the curated raid entries and column metadata in pogo_analyzer/data/raid_entries.json
- add a validated loader that reads the JSON payload, exposes metadata, and feeds DEFAULT_RAID_ENTRIES
- re-export the loader/metadata, package the JSON resource, and extend unit tests for loader error cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9f69646f88328888a0dbc25fb1a9e