### PR TITLE
Expose scoring helpers via package namespace

### DIFF
--- a/pogo_analyzer/__init__.py
+++ b/pogo_analyzer/__init__.py
@@ -14,6 +14,7 @@ from .data.raid_entries import (
     build_entry_rows,
     load_raid_entries,
 )
+from .formulas import damage_per_hit, effective_stats, infer_level_from_cp
 from .raid_entries import RAID_ENTRIES, build_rows
 from .scoreboard import (
     ExportResult,
@@ -25,6 +26,8 @@ from .scoreboard import (
     generate_scoreboard,
 )
 from .scoring import calculate_iv_bonus, calculate_raid_score, iv_bonus, raid_score
+from .pve import compute_pve_score
+from .pvp import compute_pvp_score
 from .simple_table import Row, SimpleSeries, SimpleTable
 
 
@@ -69,5 +72,10 @@ __all__ = [
     "calculate_raid_score",
     "iv_bonus",
     "raid_score",
+    "infer_level_from_cp",
+    "effective_stats",
+    "damage_per_hit",
+    "compute_pve_score",
+    "compute_pvp_score",
     "__version__",
 ]

--- a/tests/test_package_exports.py
+++ b/tests/test_package_exports.py
@@ -1,0 +1,39 @@
+"""Tests covering public package re-exports."""
+
+from __future__ import annotations
+
+from pogo_analyzer import (
+    compute_pve_score,
+    compute_pvp_score,
+    damage_per_hit,
+    effective_stats,
+    infer_level_from_cp,
+)
+from pogo_analyzer.formulas import (
+    damage_per_hit as formulas_damage_per_hit,
+    effective_stats as formulas_effective_stats,
+    infer_level_from_cp as formulas_infer_level_from_cp,
+)
+from pogo_analyzer.pve import compute_pve_score as module_compute_pve_score
+from pogo_analyzer.pvp import compute_pvp_score as module_compute_pvp_score
+
+
+def test_formulas_functions_are_reexported() -> None:
+    """Package exports should reference the underlying formula helpers."""
+
+    assert infer_level_from_cp is formulas_infer_level_from_cp
+    assert effective_stats is formulas_effective_stats
+    assert damage_per_hit is formulas_damage_per_hit
+
+
+def test_pve_function_is_reexported() -> None:
+    """Compute PvE score should be provided via the package namespace."""
+
+    assert compute_pve_score is module_compute_pve_score
+
+
+def test_pvp_function_is_reexported() -> None:
+    """Compute PvP score should be provided via the package namespace."""
+
+    assert compute_pvp_score is module_compute_pvp_score
+


### PR DESCRIPTION
## Summary
- re-export `infer_level_from_cp`, `effective_stats`, and `damage_per_hit` from `pogo_analyzer.formulas`
- expose `compute_pve_score` and `compute_pvp_score` at the package level for convenience
- add regression tests that ensure the package namespace returns the canonical implementations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb20ce85bc832881a0ef1dab5bab78