### PR TITLE
Add CLI quick-check documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python Versions](https://img.shields.io/badge/Python-3.9%E2%80%933.13-blue)](pyproject.toml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-PoGo Analyzer is a lightweight toolkit for evaluating Pokémon GO raid investments. It ships with a ready-to-run scoreboard generator that grades your Pokémon on a 1–100 scale and exports the results as CSV (and Excel when pandas is available). All functionality is implemented in pure Python so you can run the scripts anywhere, with optional pandas support for richer tabular output.
+PoGo Analyzer is a lightweight toolkit for evaluating Pokémon GO raid investments. It ships with a ready-to-run scoreboard generator that grades your Pokémon on a 1–100 scale and exports the results as CSV (and Excel when pandas is available). All functionality is implemented in pure Python so you can run the scripts anywhere, with optional pandas support for richer tabular output. The CLI also offers a single-Pokémon quick check that infers the level from Combat Power, highlights missing moves, and can surface PvE/PvP value metrics without creating export files—see the [CLI quick-check guide](docs/cli.md) for end-to-end examples.
 
 ## Table of contents
 
@@ -29,6 +29,7 @@ PoGo Analyzer is a lightweight toolkit for evaluating Pokémon GO raid investmen
 ## Features
 
 - **Raid value scoreboard** – score your roster by combining baseline species strength, IV quality, lucky cost savings, move requirements, and mega availability.
+- **CP→Level inference** – feed base stats, IVs, and Combat Power into the quick check to recover the underlying level and CPM alongside effective raid stats.
 - **Reusable scoring helpers** – import the library to compute raid scores or transform entries inside your own automation scripts.
 - **Pandas-free tables** – fall back to a minimal in-repo table implementation when pandas is not installed.
 - **Repeatable workflows** – the CLI works with configuration flags and environment variables so it is easy to wire into cron jobs or CI pipelines.
@@ -132,6 +133,8 @@ pogo-raid-scoreboard \
 The CLI prints an on-the-spot summary including the computed raid score and priority tier without generating files.
 If you already have the exclusive move unlocked, add `--has-special-move` to suppress the reminder.
 Use `--target-cp` to tell the CLI what raid-ready CP you're aiming for; it only flags builds as underpowered when a target is provided.
+
+Refer to the [CLI quick-check guide](docs/cli.md) for an expanded walkthrough that covers the available flags, expected output sections, and combined PvE/PvP scoring scenarios.
 
 ### Level inference and PvE/PvP value scoring
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,131 @@
+# CLI quick checks
+
+This guide walks through the single-Pokémon quick-check workflow exposed by `pogo-raid-scoreboard`.
+It focuses on the CLI flags that power raid (PvE) and league (PvP) evaluations so you can sanity-check
+an individual build without generating the full scoreboard export.
+
+## Flag overview
+
+| Flag | Purpose |
+| ---- | ------- |
+| `--pokemon-name` | Nickname used for the evaluation. Doubles as the lookup key for dataset guidance. |
+| `--combat-power` (`--cp`) | Observed CP used for the raid score baseline and level inference. |
+| `--ivs ATT DEF STA` | IV spread (attack, defence, stamina). Required for quick checks. |
+| `--shadow` / `--purified` / `--lucky` / `--best-buddy` (`--bb`) | Status toggles that change scoring or inference. |
+| `--needs-tm` / `--has-special-move` | Describe whether an exclusive move is already unlocked. |
+| `--target-cp` | Desired raid-ready CP. Used to flag underpowered builds. |
+| `--base-stats ATK DEF STA` | Species base stats. Required for CP→level inference, PvE, and PvP outputs. |
+| `--fast ...` / `--charge ...` | Move descriptors used to evaluate PvE rotations and PvP pressure. |
+| `--target-defense` / `--incoming-dps` / `--alpha` | PvE tuning knobs. Provide defence, incoming DPS, and DPS↔TDO blend. |
+| `--league-cap` / `--beta` / `--sp-ref` / `--mp-ref` / `--bait-prob` | PvP tuning knobs. Select league and weighting factors. |
+
+### Move descriptor recap
+
+- Fast moves: `name,power,energy_gain,duration[,stab=...][,weather=...][,type=...][,turns=...]`
+- Charged moves: `name,power,energy_cost,duration[,stab=...][,weather=...][,type=...][,reliability=...][,buff=...]`
+
+Use `turns` to unlock PvP timing, `stab=true` when the move matches species typing, and `type=`/`effectiveness=` to apply
+non-standard multipliers. Passing `--weather` boosts all moves unless explicitly overridden per descriptor.
+
+## PvE quick check
+
+Run the command below to inspect a raid build without enabling the PvE/PvP extra outputs. The CLI prints a priority
+recommendation, highlights missing exclusive moves, and surfaces dataset guidance.
+
+```bash
+pogo-raid-scoreboard \
+  --pokemon-name Hydreigon \
+  --combat-power 3200 \
+  --ivs 15 14 15 \
+  --shadow \
+  --needs-tm \
+  --notes "Needs Brutal Swing from CD."
+```
+
+Expected output:
+
+```
+Single Pokémon evaluation
+-------------------------
+Name: Hydreigon (shadow)
+Combat Power: 3200
+IVs: 15/14/15
+Recommended Charged Move: Brutal Swing
+Action: Needs Brutal Swing (Community Day / Elite TM).
+Status: Shadow, Exclusive move missing
+Raid Score: 89.0/100
+Priority Tier: A (High)
+Notes: Needs Brutal Swing from CD. Needs Brutal Swing (Community Day / Elite TM). Applied shadow damage bonus to baseline score due to missing dedicated template.
+```
+
+## PvE + PvP quick check with level inference
+
+Provide species base stats and move descriptors to unlock the extended PvE and PvP sections. The CLI infers the
+underlying level/CPM, prints the effective stats, and reports both value scores. The example below targets a
+Great League evaluation (`--league-cap 1500`).
+
+```bash
+pogo-raid-scoreboard \
+  --pokemon-name Hydreigon \
+  --combat-power 3325 \
+  --ivs 15 15 15 \
+  --base-stats 256 188 216 \
+  --fast 'Snarl,12,13,1.0,turns=4,stab=true' \
+  --charge 'Brutal Swing,65,40,1.9,stab=true' \
+  --target-defense 180 \
+  --incoming-dps 35 \
+  --alpha 0.6 \
+  --league-cap 1500 \
+  --beta 0.52
+```
+
+Expected output (abridged to the key sections):
+
+```
+Single Pokémon evaluation
+-------------------------
+Name: Hydreigon
+Combat Power: 3325
+IVs: 15/15/15
+Recommended Charged Move: Brutal Swing
+Action: Needs Brutal Swing (Community Day / Elite TM).
+Raid Score: 86.2/100
+Priority Tier: A (High)
+Notes: Needs Brutal Swing (Community Day / Elite TM).
+
+Inferred build stats
+--------------------
+Species: Hydreigon
+Level: 33.5
+CPM: 0.752729
+Effective Attack: 203.99
+Effective Defense: 152.80
+Effective HP: 173
+
+PvE value
+---------
+Rotation DPS: 14.61
+Cycle Damage: 72.69
+Cycle Time: 4.98s
+Fast Moves / Cycle: 3.08
+Charge Use / Cycle: Brutal Swing: 1.00
+EHP: 146.86
+TDO: 61.29
+PvE Value (alpha=0.60): 25.92
+
+PvP value (Great League)
+---------------------------
+Stat Product: 5392483.54
+Normalised Stat Product: 3.3703
+Move Pressure: 9.90
+Normalised Move Pressure: 0.2063
+PvP Score (beta=0.52): 0.8817
+```
+
+### Tips
+
+- Supply additional `--charge` descriptors when a PvP set relies on multiple charged moves; the CLI tracks per-cycle usage.
+- Use `--observed-hp` whenever multiple levels share the same CP (common around level 15). The additional data point lets the
+  inference step pick the correct level.
+- Pass `--weather` to boost all moves simultaneously; override specific moves with `weather=false` or `type=1.6` tokens.
+- League presets follow Great (default), Ultra (`--league-cap 2500`), and Master (omit the cap to evaluate unrestricted stats).


### PR DESCRIPTION
## Summary
- document the quick-check workflow in a new docs/cli.md guide with PvE and PvP examples
- highlight CP-to-level inference and link to the new quick-start guide from the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb26a127148328838fcf82eba9edf0