### PR TITLE
Add regression tests for level inference and scoring examples

### DIFF
--- a/tests/test_infer_level_edge_cases.py
+++ b/tests/test_infer_level_edge_cases.py
@@ -1,0 +1,102 @@
+"""Regression tests for level inference edge conditions."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from pogo_analyzer.cpm_table import get_cpm
+from pogo_analyzer.formulas import infer_level_from_cp
+
+
+def _cp_and_hp(
+    base_attack: int,
+    base_defense: int,
+    base_stamina: int,
+    iv_attack: int,
+    iv_defense: int,
+    iv_stamina: int,
+    level: float,
+) -> tuple[int, int]:
+    """Return the (CP, HP) pair for a Pokémon at a specific level."""
+
+    cpm = get_cpm(level)
+    attack = base_attack + iv_attack
+    defense = base_defense + iv_defense
+    stamina = base_stamina + iv_stamina
+    cp = math.floor(attack * math.sqrt(defense) * math.sqrt(stamina) * cpm**2 / 10)
+    hp = math.floor(stamina * cpm)
+    return cp, hp
+
+
+def test_infer_level_negative_cp_raises() -> None:
+    with pytest.raises(ValueError, match="CP must be non-negative"):
+        infer_level_from_cp(200, 200, 200, 10, 10, 10, -1)
+
+
+def test_infer_level_negative_observed_hp_raises() -> None:
+    with pytest.raises(ValueError, match="Observed HP must be non-negative"):
+        infer_level_from_cp(180, 180, 180, 12, 12, 12, 1000, observed_hp=-5)
+
+
+def test_infer_level_requires_hp_to_break_cp_collision() -> None:
+    base_attack = base_defense = base_stamina = 30
+    iv_attack = iv_defense = iv_stamina = 0
+    level_low = 17.5
+    level_high = 18.0
+
+    cp, hp_low = _cp_and_hp(
+        base_attack,
+        base_defense,
+        base_stamina,
+        iv_attack,
+        iv_defense,
+        iv_stamina,
+        level_low,
+    )
+    cp_check, hp_high = _cp_and_hp(
+        base_attack,
+        base_defense,
+        base_stamina,
+        iv_attack,
+        iv_defense,
+        iv_stamina,
+        level_high,
+    )
+    assert cp == cp_check  # Sanity check that the collision is real.
+
+    with pytest.raises(ValueError, match="multiple levels"):
+        infer_level_from_cp(
+            base_attack,
+            base_defense,
+            base_stamina,
+            iv_attack,
+            iv_defense,
+            iv_stamina,
+            cp,
+        )
+
+    level, _ = infer_level_from_cp(
+        base_attack,
+        base_defense,
+        base_stamina,
+        iv_attack,
+        iv_defense,
+        iv_stamina,
+        cp,
+        observed_hp=hp_high,
+    )
+    assert level == pytest.approx(level_high)
+
+    with pytest.raises(ValueError, match="does not match any level"):
+        infer_level_from_cp(
+            base_attack,
+            base_defense,
+            base_stamina,
+            iv_attack,
+            iv_defense,
+            iv_stamina,
+            cp,
+            observed_hp=hp_high + 5,
+        )

--- a/tests/test_pve_rotation_examples.py
+++ b/tests/test_pve_rotation_examples.py
@@ -1,0 +1,62 @@
+"""Golden tests for PvE rotation scoring helpers."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+from pogo_analyzer.formulas import effective_stats, infer_level_from_cp
+from pogo_analyzer.pve import ChargeMove, FastMove, compute_pve_score, rotation_dps
+
+
+@pytest.fixture(scope="module")
+def hydreigon_build() -> tuple[float, float, int]:
+    level, _ = infer_level_from_cp(256, 188, 216, 15, 15, 15, 3325)
+    attack, defense, hp = effective_stats(256, 188, 216, 15, 15, 15, level)
+    return attack, defense, hp
+
+
+@pytest.fixture(scope="module")
+def hydreigon_moves() -> tuple[FastMove, list[ChargeMove]]:
+    fast = FastMove("Snarl", power=12, energy_gain=13, duration=1.0, stab=True)
+    charge = ChargeMove("Brutal Swing", power=65, energy_cost=40, duration=1.9, stab=True)
+    return fast, [charge]
+
+
+def test_rotation_dps_matches_cli_example(
+    hydreigon_build: tuple[float, float, int], hydreigon_moves: tuple[FastMove, list[ChargeMove]]
+) -> None:
+    attack, _, _ = hydreigon_build
+    fast_move, charge_moves = hydreigon_moves
+
+    result = rotation_dps(fast_move, charge_moves, attack, 180.0)
+
+    assert result == pytest.approx(14.605873261205565, rel=1e-9)
+
+
+def test_compute_pve_score_hydreigon_example(
+    hydreigon_build: tuple[float, float, int], hydreigon_moves: tuple[FastMove, list[ChargeMove]]
+) -> None:
+    attack, defense, hp = hydreigon_build
+    fast_move, charge_moves = hydreigon_moves
+
+    score = compute_pve_score(
+        attack,
+        defense,
+        hp,
+        fast_move,
+        charge_moves,
+        target_defense=180.0,
+        incoming_dps=35.0,
+        alpha=0.6,
+    )
+
+    assert score["dps"] == pytest.approx(14.605873261205565, rel=1e-9)
+    assert score["cycle_damage"] == pytest.approx(72.6923076923077, rel=1e-9)
+    assert score["cycle_time"] == pytest.approx(4.976923076923077, rel=1e-9)
+    assert score["fast_moves_per_cycle"] == pytest.approx(3.0769230769230766, rel=1e-9)
+    assert score["charge_usage_per_cycle"] == Counter({"Brutal Swing": 1})
+    assert score["ehp"] == pytest.approx(146.86162664342945, rel=1e-9)
+    assert score["tdo"] == pytest.approx(61.286923019669175, rel=1e-9)
+    assert score["value"] == pytest.approx(25.921709769448622, rel=1e-9)

--- a/tests/test_pvp_score_examples.py
+++ b/tests/test_pvp_score_examples.py
@@ -1,0 +1,45 @@
+"""Regression tests for PvP score calculations against known builds."""
+
+from __future__ import annotations
+
+import pytest
+
+from pogo_analyzer.formulas import effective_stats, infer_level_from_cp
+from pogo_analyzer.pvp import PvpChargeMove, PvpFastMove, compute_pvp_score
+
+
+@pytest.fixture(scope="module")
+def hydreigon_build() -> tuple[float, float, int]:
+    level, _ = infer_level_from_cp(256, 188, 216, 15, 15, 15, 3325)
+    attack, defense, hp = effective_stats(256, 188, 216, 15, 15, 15, level)
+    return attack, defense, hp
+
+
+@pytest.fixture(scope="module")
+def hydreigon_moves() -> tuple[PvpFastMove, list[PvpChargeMove]]:
+    fast = PvpFastMove("Snarl", damage=5, energy_gain=13, turns=4)
+    charge = PvpChargeMove("Brutal Swing", damage=65, energy_cost=40)
+    return fast, [charge]
+
+
+def test_compute_pvp_score_matches_reference(
+    hydreigon_build: tuple[float, float, int], hydreigon_moves: tuple[PvpFastMove, list[PvpChargeMove]]
+) -> None:
+    attack, defense, hp = hydreigon_build
+    fast_move, charge_moves = hydreigon_moves
+
+    result = compute_pvp_score(
+        attack,
+        defense,
+        hp,
+        fast_move,
+        charge_moves,
+        league="great",
+        beta=0.52,
+    )
+
+    assert result["stat_product"] == pytest.approx(5_392_483.542653858, rel=1e-12)
+    assert result["stat_product_normalised"] == pytest.approx(3.370302214158661, rel=1e-12)
+    assert result["move_pressure"] == pytest.approx(6.4, rel=1e-12)
+    assert result["move_pressure_normalised"] == pytest.approx(0.13333333333333333, rel=1e-12)
+    assert result["score"] == pytest.approx(0.7150861940536062, rel=1e-12)


### PR DESCRIPTION
## Summary
- add level inference regression coverage for CP collisions and input validation
- capture Hydreigon PvE rotation metrics from the CLI example as a golden test
- pin Hydreigon Great League PvP values to guard the new scoring helpers

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cb27aa6b788328bc1083d765dfb71d