### PR TITLE
Fix fast move turn validation

### DIFF
--- a/raid_scoreboard_generator.py
+++ b/raid_scoreboard_generator.py
@@ -413,6 +413,8 @@ def _parse_fast_move(value: str, *, default_weather: bool) -> _ParsedFastMove:
             turns_value = float(extras["turns"])
         except ValueError as exc:  # pragma: no cover - defensive guard.
             raise ValueError("Fast move turns must be numeric when provided.") from exc
+        if not turns_value.is_integer():
+            raise ValueError("Fast move turns must be an integer when provided.")
         turns = int(turns_value)
         if turns <= 0:
             raise ValueError("Fast move turns must be positive when provided.")

--- a/tests/test_raid_scoreboard.py
+++ b/tests/test_raid_scoreboard.py
@@ -206,6 +206,16 @@ def test_add_priority_tier_assigns_expected_labels() -> None:
     ]
 
 
+def test_parse_fast_move_rejects_fractional_turns() -> None:
+    """Fractional turn values should fail fast to guard against malformed inputs."""
+
+    with pytest.raises(ValueError, match="Fast move turns must be an integer"):
+        rsg._parse_fast_move(
+            "Example Fast,10,5,0.5,turns=1.5",
+            default_weather=False,
+        )
+
+
 def test_canonical_api_aliases() -> None:
     """New naming exports should remain in sync with legacy helpers."""
 


### PR DESCRIPTION
## Summary
- ensure fast move turn descriptors require whole-number values before conversion
- add regression coverage for fractional turns being rejected

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cb2eb9a4b08328bd7392588fcfae92